### PR TITLE
Add support for the GCP and OIDC auth providers

### DIFF
--- a/kubernetes/clientset.go
+++ b/kubernetes/clientset.go
@@ -16,8 +16,12 @@ package kubernetes
 
 import (
 	"github.com/pkg/errors"
-	"k8s.io/client-go/1.4/kubernetes"
-	"k8s.io/client-go/1.4/tools/clientcmd"
+	"k8s.io/client-go/1.5/kubernetes"
+	"k8s.io/client-go/1.5/tools/clientcmd"
+
+	// auth providers
+	_ "k8s.io/client-go/1.5/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/1.5/plugin/pkg/client/auth/oidc"
 )
 
 // NewClientSet returns a new Kubernetes client set for a context

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -23,9 +23,9 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 
-	corev1 "k8s.io/client-go/1.4/kubernetes/typed/core/v1"
-	"k8s.io/client-go/1.4/pkg/api/v1"
-	"k8s.io/client-go/1.4/rest"
+	corev1 "k8s.io/client-go/1.5/kubernetes/typed/core/v1"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/rest"
 )
 
 type Tail struct {

--- a/stern/watch.go
+++ b/stern/watch.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/pkg/errors"
 
-	corev1 "k8s.io/client-go/1.4/kubernetes/typed/core/v1"
-	"k8s.io/client-go/1.4/pkg/api"
-	"k8s.io/client-go/1.4/pkg/api/v1"
-	"k8s.io/client-go/1.4/pkg/watch"
+	corev1 "k8s.io/client-go/1.5/kubernetes/typed/core/v1"
+	"k8s.io/client-go/1.5/pkg/api"
+	"k8s.io/client-go/1.5/pkg/api/v1"
+	"k8s.io/client-go/1.5/pkg/watch"
 )
 
 // Target is a target to watch

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1,12 +1,36 @@
 {
 	"comment": "",
-	"ignore": "",
+	"ignore": "appengine",
 	"package": [
 		{
-			"checksumSHA1": "ZUoYBJcCAc+K5+FsWFcvk5LAJEU=",
+			"checksumSHA1": "BvDUxKpaWSE45ClbXX81wPAgeKE=",
+			"path": "cloud.google.com/go/compute/metadata",
+			"revision": "78759a61330946eb0d8f57eb6f88a7c7d6574912",
+			"revisionTime": "2016-12-13T23:12:04Z"
+		},
+		{
+			"checksumSHA1": "dMDfOzNr3Cwy0V3wX5x98plV/GI=",
+			"path": "cloud.google.com/go/internal",
+			"revision": "78759a61330946eb0d8f57eb6f88a7c7d6574912",
+			"revisionTime": "2016-12-13T23:12:04Z"
+		},
+		{
+			"checksumSHA1": "w8Ske8GudAzbg6MCB5qoy+A+/Gw=",
+			"path": "github.com/PuerkitoBio/purell",
+			"revision": "0bcb03f4b4d0a9428594752bd2a3b9aa0a9d4bd4",
+			"revisionTime": "2016-11-15T02:49:42Z"
+		},
+		{
+			"checksumSHA1": "sGlxFtDp+2esf88nbx44xoXqJcc=",
+			"path": "github.com/PuerkitoBio/urlesc",
+			"revision": "5bd2802263f21d8788851d5305584c82a5c75d7e",
+			"revisionTime": "2016-07-26T15:08:25Z"
+		},
+		{
+			"checksumSHA1": "Xk/ERIWpZj0nqUEnjQ6xPIrqz2o=",
 			"path": "github.com/blang/semver",
-			"revision": "60ec3488bfea7cca02b021d106d9911120d25fe9",
-			"revisionTime": "2016-07-01T05:46:53Z"
+			"revision": "3a37c301dda64cbe17f16f661b4c976803c0e2d2",
+			"revisionTime": "2016-11-30T00:12:39Z"
 		},
 		{
 			"checksumSHA1": "WOY645oaOR6NqP38Yk/ApjNK63U=",
@@ -15,52 +39,100 @@
 			"revisionTime": "2016-04-29T08:01:25Z"
 		},
 		{
-			"checksumSHA1": "kBqynwuhOcuu3Tnt3yHQRyu+eMU=",
+			"checksumSHA1": "wmwKvJJ8E9UXANWY68g6cOBRI70=",
+			"path": "github.com/coreos/go-oidc/http",
+			"revision": "dedb650fb29c39c2f21aa88c1e4cec66da8754d1",
+			"revisionTime": "2016-11-29T23:46:13Z"
+		},
+		{
+			"checksumSHA1": "0lGeODNl8EHCPSr6dvDrQtn5+gw=",
+			"path": "github.com/coreos/go-oidc/jose",
+			"revision": "dedb650fb29c39c2f21aa88c1e4cec66da8754d1",
+			"revisionTime": "2016-11-29T23:46:13Z"
+		},
+		{
+			"checksumSHA1": "VQ1S7w5jsQs+nIgjeDrpZ1WKRJA=",
+			"path": "github.com/coreos/go-oidc/key",
+			"revision": "dedb650fb29c39c2f21aa88c1e4cec66da8754d1",
+			"revisionTime": "2016-11-29T23:46:13Z"
+		},
+		{
+			"checksumSHA1": "uBQX6YTQmT9uhXmseRwnx4pHk2Q=",
+			"path": "github.com/coreos/go-oidc/oauth2",
+			"revision": "dedb650fb29c39c2f21aa88c1e4cec66da8754d1",
+			"revisionTime": "2016-11-29T23:46:13Z"
+		},
+		{
+			"checksumSHA1": "UP0smp3toqq9zI1PN371lNt3Qbk=",
+			"path": "github.com/coreos/go-oidc/oidc",
+			"revision": "dedb650fb29c39c2f21aa88c1e4cec66da8754d1",
+			"revisionTime": "2016-11-29T23:46:13Z"
+		},
+		{
+			"checksumSHA1": "irNRboo9dWf9VvmM+T3lOeL+G8M=",
+			"path": "github.com/coreos/pkg/health",
+			"revision": "447b7ec906e523386d9c53be15b55a8ae86ea944",
+			"revisionTime": "2016-10-26T22:29:26Z"
+		},
+		{
+			"checksumSHA1": "kt/IM3Mg9HIaUWlAgMs1a1yRE08=",
+			"path": "github.com/coreos/pkg/httputil",
+			"revision": "447b7ec906e523386d9c53be15b55a8ae86ea944",
+			"revisionTime": "2016-10-26T22:29:26Z"
+		},
+		{
+			"checksumSHA1": "xJ7LtJkBAPyvsE/q+nNd3uoc8TQ=",
+			"path": "github.com/coreos/pkg/timeutil",
+			"revision": "447b7ec906e523386d9c53be15b55a8ae86ea944",
+			"revisionTime": "2016-10-26T22:29:26Z"
+		},
+		{
+			"checksumSHA1": "om34bF5kyeENDAsuNqxICt7vPKg=",
 			"path": "github.com/davecgh/go-spew/spew",
-			"revision": "6d212800a42e8ab5c146b8ace3490ee17e5225f9",
-			"revisionTime": "2016-09-07T16:21:46Z"
+			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
 			"checksumSHA1": "a2yC46a1qsJomgY6rb+FkTFiqmE=",
 			"path": "github.com/davecgh/go-spew/spew/testdata",
-			"revision": "6d212800a42e8ab5c146b8ace3490ee17e5225f9",
-			"revisionTime": "2016-09-07T16:21:46Z"
+			"revision": "346938d642f2ec3594ed81d874461961cd0faa76",
+			"revisionTime": "2016-10-29T20:57:26Z"
 		},
 		{
-			"checksumSHA1": "66UlS6CE2174+Nj5T3wyLX3J/6U=",
+			"checksumSHA1": "/o1yaHi/06pwJXMyygRT4JbLPNQ=",
 			"path": "github.com/docker/distribution/digest",
-			"revision": "431cfa3179d9b3766e39f6a74283db8bb5a13209",
-			"revisionTime": "2016-09-19T23:27:56Z"
+			"revision": "923c7763b0e49cbb9f34da368108e8dde34e009d",
+			"revisionTime": "2016-12-09T17:51:46Z"
 		},
 		{
-			"checksumSHA1": "pxN7XMC//RzBJcavcFjiGVWLFdI=",
+			"checksumSHA1": "aK/aB2ZWLsXFeoJG6e9rH89guKU=",
 			"path": "github.com/docker/distribution/reference",
-			"revision": "431cfa3179d9b3766e39f6a74283db8bb5a13209",
-			"revisionTime": "2016-09-19T23:27:56Z"
+			"revision": "923c7763b0e49cbb9f34da368108e8dde34e009d",
+			"revisionTime": "2016-12-09T17:51:46Z"
 		},
 		{
-			"checksumSHA1": "ZlwCbPzsNL40sdtwloE8oyVpKjQ=",
+			"checksumSHA1": "I6SR88xv8ndbtAr44WmjdzqmcQc=",
 			"path": "github.com/emicklei/go-restful",
-			"revision": "3d66f886316ac990eb502aaa89ea38546420b8b7",
-			"revisionTime": "2016-09-22T07:44:15Z"
+			"revision": "09691a3b6378b740595c1002f40c34dd5f218a22",
+			"revisionTime": "2016-12-12T08:45:25Z"
 		},
 		{
 			"checksumSHA1": "3xWz4fZ9xW+CfADpYoPFcZCYJ4E=",
 			"path": "github.com/emicklei/go-restful/log",
-			"revision": "3d66f886316ac990eb502aaa89ea38546420b8b7",
-			"revisionTime": "2016-09-22T07:44:15Z"
+			"revision": "09691a3b6378b740595c1002f40c34dd5f218a22",
+			"revisionTime": "2016-12-12T08:45:25Z"
 		},
 		{
-			"checksumSHA1": "L7+fH+QEjdsEQAukXThp/TmxImU=",
+			"checksumSHA1": "bSpdwKV/+FVunuVe6564pBLPUpk=",
 			"path": "github.com/emicklei/go-restful/swagger",
-			"revision": "3d66f886316ac990eb502aaa89ea38546420b8b7",
-			"revisionTime": "2016-09-22T07:44:15Z"
+			"revision": "09691a3b6378b740595c1002f40c34dd5f218a22",
+			"revisionTime": "2016-12-12T08:45:25Z"
 		},
 		{
 			"checksumSHA1": "VFVNNgHCeoRC8WY/gE+3AYPqKyE=",
 			"path": "github.com/emicklei/go-restful/swagger/test_package",
-			"revision": "3d66f886316ac990eb502aaa89ea38546420b8b7",
-			"revisionTime": "2016-09-22T07:44:15Z"
+			"revision": "09691a3b6378b740595c1002f40c34dd5f218a22",
+			"revisionTime": "2016-12-12T08:45:25Z"
 		},
 		{
 			"checksumSHA1": "BXNbMbPFcJXtZpZ8sZF0mGbv9tY=",
@@ -69,46 +141,70 @@
 			"revisionTime": "2016-06-10T11:06:02Z"
 		},
 		{
-			"checksumSHA1": "tlamwNO+LGDdSX97T+EtBrjA07E=",
+			"checksumSHA1": "WkATORVhFX2Q+XYua1YcwSqqg54=",
 			"path": "github.com/ghodss/yaml",
-			"revision": "aa0c862057666179de291b67d9f093d12b5a8473",
-			"revisionTime": "2016-06-04T00:29:25Z"
+			"revision": "04f313413ffd65ce25f2541bfd2b2ceec5c0908c",
+			"revisionTime": "2016-12-07T00:33:20Z"
 		},
 		{
-			"checksumSHA1": "tsCby569Su2eWSY9WrZqSe3MERA=",
+			"checksumSHA1": "250AvKvb87TLbiBphI4tRJVuTds=",
+			"path": "github.com/go-openapi/jsonpointer",
+			"revision": "8d96a2dc61536b690bd36b2e9df0b3c0b62825b2",
+			"revisionTime": "2016-11-05T16:15:41Z"
+		},
+		{
+			"checksumSHA1": "scLbSsA/Yycgnem1UArYOUp+QFI=",
+			"path": "github.com/go-openapi/jsonreference",
+			"revision": "36d33bfe519efae5632669801b180bf1a245da3b",
+			"revisionTime": "2016-11-05T16:21:50Z"
+		},
+		{
+			"checksumSHA1": "aTRPO6WfBLPmsYTTDmOh2+dJuB4=",
+			"path": "github.com/go-openapi/spec",
+			"revision": "f7ae86df5bc115a2744343016c789a89f065a4bd",
+			"revisionTime": "2016-11-19T16:27:01Z"
+		},
+		{
+			"checksumSHA1": "m0K4IKzz/y8TEE4tePRUVzKISH4=",
+			"path": "github.com/go-openapi/swag",
+			"revision": "3b6d86cd965820f968760d5d419cb4add096bdd7",
+			"revisionTime": "2016-10-24T02:49:19Z"
+		},
+		{
+			"checksumSHA1": "rBVq79T413f7Sr49+gy+UT8ld4k=",
 			"path": "github.com/gogo/protobuf/proto",
-			"revision": "a31fa025390fe54d2af14a04199ed08dea5dc2fd",
-			"revisionTime": "2016-09-19T18:48:08Z"
+			"revision": "06ec6c31ff1bac6ed4e205a547a3d72934813ef3",
+			"revisionTime": "2016-12-10T18:20:26Z"
 		},
 		{
-			"checksumSHA1": "Xf+n/ealiE86dS/oozQKQCTAzDg=",
+			"checksumSHA1": "SCNkP3l6j3InUHuPQwVq2rTTbjM=",
 			"path": "github.com/gogo/protobuf/proto/proto3_proto",
-			"revision": "a31fa025390fe54d2af14a04199ed08dea5dc2fd",
-			"revisionTime": "2016-09-19T18:48:08Z"
+			"revision": "06ec6c31ff1bac6ed4e205a547a3d72934813ef3",
+			"revisionTime": "2016-12-10T18:20:26Z"
 		},
 		{
-			"checksumSHA1": "lhHvvYZf2AGS33moYvWob+3g5OI=",
+			"checksumSHA1": "q3CRTyC7WnwDImBxtSis7/YyZ2Q=",
 			"path": "github.com/gogo/protobuf/proto/testdata",
-			"revision": "a31fa025390fe54d2af14a04199ed08dea5dc2fd",
-			"revisionTime": "2016-09-19T18:48:08Z"
+			"revision": "06ec6c31ff1bac6ed4e205a547a3d72934813ef3",
+			"revisionTime": "2016-12-10T18:20:26Z"
 		},
 		{
-			"checksumSHA1": "zVCBnBzjkmL1Gkll/7IbpKKprmw=",
+			"checksumSHA1": "hYK1CRhLliJkGqOLcX0mvt3EjJ4=",
 			"path": "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
-			"revision": "a31fa025390fe54d2af14a04199ed08dea5dc2fd",
-			"revisionTime": "2016-09-19T18:48:08Z"
+			"revision": "06ec6c31ff1bac6ed4e205a547a3d72934813ef3",
+			"revisionTime": "2016-12-10T18:20:26Z"
 		},
 		{
 			"checksumSHA1": "HPVQZu059/Rfw2bAWM538bVTcUc=",
 			"path": "github.com/gogo/protobuf/sortkeys",
-			"revision": "a31fa025390fe54d2af14a04199ed08dea5dc2fd",
-			"revisionTime": "2016-09-19T18:48:08Z"
+			"revision": "06ec6c31ff1bac6ed4e205a547a3d72934813ef3",
+			"revisionTime": "2016-12-10T18:20:26Z"
 		},
 		{
-			"checksumSHA1": "fQ6L7DQYWAGYxTju2y80HAqr+qo=",
+			"checksumSHA1": "HqgL90iIkRvAuOLl68qpo2lXP4Q=",
 			"path": "github.com/gogo/protobuf/types",
-			"revision": "a31fa025390fe54d2af14a04199ed08dea5dc2fd",
-			"revisionTime": "2016-09-19T18:48:08Z"
+			"revision": "06ec6c31ff1bac6ed4e205a547a3d72934813ef3",
+			"revisionTime": "2016-12-10T18:20:26Z"
 		},
 		{
 			"checksumSHA1": "yUc84k7cfnRi9AlPFuRo77Y18Og=",
@@ -117,34 +213,70 @@
 			"revisionTime": "2016-01-25T20:49:56Z"
 		},
 		{
-			"checksumSHA1": "7kHC8QJD74DCyQRYTxVP5AC4m2k=",
+			"checksumSHA1": "yeFSOloBGZmhZZZ60SxtecgJfkQ=",
 			"path": "github.com/golang/protobuf/proto",
-			"revision": "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
-			"revisionTime": "2016-08-24T20:12:15Z"
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
-			"checksumSHA1": "5CLH5JkO7pTla/+vPq8axMEjzD4=",
+			"checksumSHA1": "qyalT+838zrkZMjOA62VGus0VcI=",
 			"path": "github.com/golang/protobuf/proto/proto3_proto",
-			"revision": "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
-			"revisionTime": "2016-08-24T20:12:15Z"
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
-			"checksumSHA1": "sAQaJhuPZpEaC90zTorUWG0/LlI=",
+			"checksumSHA1": "hKyIpAqeYU2nAl/oXcpATnNaiBI=",
 			"path": "github.com/golang/protobuf/proto/testdata",
-			"revision": "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
-			"revisionTime": "2016-08-24T20:12:15Z"
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
+		},
+		{
+			"checksumSHA1": "AjyXQ5eohrCPS/jSWZFPn5E8wnQ=",
+			"path": "github.com/golang/protobuf/protoc-gen-go/descriptor",
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
+		},
+		{
+			"checksumSHA1": "Y89zrH1jPTV2yIjp2JtYJ/v3e1s=",
+			"path": "github.com/golang/protobuf/ptypes",
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
 			"checksumSHA1": "lZFWy27Qo6+m/keDjNFYTxSmvZw=",
 			"path": "github.com/golang/protobuf/ptypes/any",
-			"revision": "1f49d83d9aa00e6ce4fc8258c71cc7786aec968a",
-			"revisionTime": "2016-08-24T20:12:15Z"
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
 		},
 		{
-			"checksumSHA1": "dLZsYwz718krPI21yUv2SQWlX58=",
+			"checksumSHA1": "8gDNKfvEupesDdOCXio3AK/XVaA=",
+			"path": "github.com/golang/protobuf/ptypes/duration",
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
+		},
+		{
+			"checksumSHA1": "sfoot+dHmmOgWZS6GJ5X79ClZM0=",
+			"path": "github.com/golang/protobuf/ptypes/timestamp",
+			"revision": "8ee79997227bf9b34611aee7946ae64735e6fd93",
+			"revisionTime": "2016-11-17T03:31:26Z"
+		},
+		{
+			"checksumSHA1": "3li7536XWPdPG2i28vcJTe/c3CY=",
 			"path": "github.com/google/gofuzz",
-			"revision": "fd52762d25a41827db7ef64c43756fd4b9f7e382",
-			"revisionTime": "2016-02-01T17:48:07Z"
+			"revision": "44d81051d367757e1c7c6a5a86423ece9afcf63c",
+			"revisionTime": "2016-11-22T19:10:42Z"
+		},
+		{
+			"checksumSHA1": "HXrKXzLuGf6COtRsKYak0uMwmbY=",
+			"path": "github.com/googleapis/gax-go",
+			"revision": "da06d194a00e19ce00d9011a13931c3f6f6887c7",
+			"revisionTime": "2016-11-07T00:24:06Z"
+		},
+		{
+			"checksumSHA1": "n2nEnOVMvZziaPMuud9eQMQamW4=",
+			"path": "github.com/howeyc/gopass",
+			"revision": "f5387c492211eb133053880d23dfae62aa14123d",
+			"revisionTime": "2016-10-03T13:09:00Z"
 		},
 		{
 			"checksumSHA1": "H9S5xwBvrCqJqte/RGxwl68MWJg=",
@@ -153,10 +285,46 @@
 			"revisionTime": "2016-05-17T06:44:35Z"
 		},
 		{
+			"checksumSHA1": "cxz0JXkeS4nazxatJkaCdrMeNgM=",
+			"path": "github.com/jonboulle/clockwork",
+			"revision": "bcac9884e7502bb2b474c0339d889cb981a2f27f",
+			"revisionTime": "2016-09-07T12:20:59Z"
+		},
+		{
 			"checksumSHA1": "40Ggu36mmmYUilbZtkq1uUI8PSE=",
 			"path": "github.com/juju/ratelimit",
 			"revision": "77ed1c8a01217656d2080ad51981f6e99adaa177",
 			"revisionTime": "2015-11-25T20:19:25Z"
+		},
+		{
+			"checksumSHA1": "/dLK/DJjrXhN1dPkAYy72ueVi28=",
+			"path": "github.com/kylelemons/godebug/diff",
+			"revision": "d99083b96f422f8fd5a93bc02040acec769e178f",
+			"revisionTime": "2016-11-09T21:01:02Z"
+		},
+		{
+			"checksumSHA1": "P+7WNYrWn+TUIqSZwbqD4PbNENY=",
+			"path": "github.com/kylelemons/godebug/pretty",
+			"revision": "d99083b96f422f8fd5a93bc02040acec769e178f",
+			"revisionTime": "2016-11-09T21:01:02Z"
+		},
+		{
+			"checksumSHA1": "Os9zOV8aOYDofmvtrJBfCPBC8nQ=",
+			"path": "github.com/mailru/easyjson/buffer",
+			"revision": "9d6630dc8c577b56cb9687a9cf9e8578aca7298a",
+			"revisionTime": "2016-12-12T11:23:59Z"
+		},
+		{
+			"checksumSHA1": "cmznyZg7mys5BxdvyrggSwsp64A=",
+			"path": "github.com/mailru/easyjson/jlexer",
+			"revision": "9d6630dc8c577b56cb9687a9cf9e8578aca7298a",
+			"revisionTime": "2016-12-12T11:23:59Z"
+		},
+		{
+			"checksumSHA1": "Bn9G5eAKAISNmfGdVJPsyXIjUHw=",
+			"path": "github.com/mailru/easyjson/jwriter",
+			"revision": "9d6630dc8c577b56cb9687a9cf9e8578aca7298a",
+			"revisionTime": "2016-12-12T11:23:59Z"
 		},
 		{
 			"checksumSHA1": "ZAlzPBSsaGe/k5pbISRQvSiVhfc=",
@@ -165,7 +333,7 @@
 			"revisionTime": "2016-07-31T23:54:17Z"
 		},
 		{
-			"checksumSHA1": "xZuhljnmBysJPta/lMyYmJdujCg=",
+			"checksumSHA1": "1otkAg+0Q9NksNSuQ3ijCW0xHxE=",
 			"path": "github.com/mattn/go-isatty",
 			"revision": "66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8",
 			"revisionTime": "2016-08-06T12:27:52Z"
@@ -357,10 +525,10 @@
 			"revisionTime": "2016-09-11T05:10:23Z"
 		},
 		{
-			"checksumSHA1": "W5ipMLrFEUJLdAeVil1hQi/hJ00=",
+			"checksumSHA1": "WEDoqnBZflraOp2F5NG96PDBC9M=",
 			"path": "github.com/pborman/uuid",
-			"revision": "b984ec7fa9ff9e428bd0cf0abf429384dfbe3e37",
-			"revisionTime": "2016-08-24T21:06:00Z"
+			"revision": "5007efa264d92316c43112bc573e754bc889b7b1",
+			"revisionTime": "2016-12-06T18:47:45Z"
 		},
 		{
 			"checksumSHA1": "NMj8X++8UgwUQhA5mv7RzQplU5U=",
@@ -369,70 +537,328 @@
 			"revisionTime": "2016-09-16T11:02:12Z"
 		},
 		{
-			"checksumSHA1": "oPIydY1lGw52tBFFOW9jnsBVO7M=",
+			"checksumSHA1": "RZOdTSZN/PgcTqko5LzIAzw+UT4=",
+			"path": "github.com/pmezard/go-difflib/difflib",
+			"revision": "792786c7400a136282c1664665ae0a8db921c6c2",
+			"revisionTime": "2016-01-10T10:55:54Z"
+		},
+		{
+			"checksumSHA1": "G2laO+0eNWudaTAt24gwMsGUptM=",
 			"path": "github.com/spf13/pflag",
-			"revision": "c7e63cf4530bcd3ba943729cee0efeff2ebea63f",
-			"revisionTime": "2016-09-15T15:31:01Z"
+			"revision": "25f8b5b07aece3207895bf19f7ab517eb3b22a40",
+			"revisionTime": "2016-12-14T04:49:49Z"
 		},
 		{
 			"checksumSHA1": "KryCFMSBWiYWd9cvnc/OaKONvnU=",
 			"path": "github.com/stevvooe/resumable",
-			"revision": "eb352b28d119500cb0382a8379f639c1c8d65831",
-			"revisionTime": "2015-08-25T01:39:42Z"
+			"revision": "f714bdb9b57a7162bc99aaa0b68a338c0da1c392",
+			"revisionTime": "2016-09-23T20:34:40Z"
 		},
 		{
-			"checksumSHA1": "6isKzf2GjYi8yOFnJg9SZE12xWI=",
+			"checksumSHA1": "x53vB16DNpAXlW+Xx/fQem9nuV4=",
 			"path": "github.com/stevvooe/resumable/sha256",
-			"revision": "eb352b28d119500cb0382a8379f639c1c8d65831",
-			"revisionTime": "2015-08-25T01:39:42Z"
+			"revision": "f714bdb9b57a7162bc99aaa0b68a338c0da1c392",
+			"revisionTime": "2016-09-23T20:34:40Z"
 		},
 		{
-			"checksumSHA1": "NSsNJMNfl0agqnAoTNntSE64h0E=",
+			"checksumSHA1": "FQxphxs1ORrfgfaeVz34UvgV+/8=",
+			"path": "github.com/stretchr/testify/assert",
+			"revision": "18a02ba4a312f95da08ff4cfc0055750ce50ae9e",
+			"revisionTime": "2016-11-17T07:43:51Z"
+		},
+		{
+			"checksumSHA1": "gowLbyV296PjZ5jq4oaiM8T55iY=",
 			"path": "github.com/ugorji/go/codec",
-			"revision": "b7eff9abce531d6aeda923e759ae668e56601d21",
-			"revisionTime": "2016-09-21T01:57:43Z"
+			"revision": "9c7f9b7a2bc3a520f7c7b30b34b7f85f47fe27b6",
+			"revisionTime": "2016-11-30T06:17:42Z"
 		},
 		{
-			"checksumSHA1": "88lxkrVVZyBqOBOFnNMBwEexiLY=",
+			"checksumSHA1": "bq5TaqWY6gHaA/oobrIYiH7A9hg=",
+			"path": "golang.org/x/crypto/ssh/terminal",
+			"revision": "9a6f0a01987842989747adff311d80750ba25530",
+			"revisionTime": "2016-12-10T14:54:14Z"
+		},
+		{
+			"checksumSHA1": "jr9CBChWOd6ZdXNikH8Hbx6PuVo=",
 			"path": "golang.org/x/net/context",
-			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
-			"revisionTime": "2016-09-11T09:39:33Z"
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
 		},
 		{
-			"checksumSHA1": "PnxoOCp9yjrv0C1GG8kVTwXIRzU=",
+			"checksumSHA1": "LolXS3+kS96mT/9wLQVhVmeIDCU=",
+			"path": "golang.org/x/net/context/ctxhttp",
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
+		},
+		{
+			"checksumSHA1": "oN/pE31vdEsyZQZEqFKdx0an/oU=",
 			"path": "golang.org/x/net/http2",
-			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
-			"revisionTime": "2016-09-11T09:39:33Z"
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
 		},
 		{
 			"checksumSHA1": "59c8b4Fzij9W7gQkAQFTnjrZ1O0=",
 			"path": "golang.org/x/net/http2/hpack",
-			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
-			"revisionTime": "2016-09-11T09:39:33Z"
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
 		},
 		{
 			"checksumSHA1": "n5oKv09EMGZZ9GUWdLiXZRzEsg0=",
 			"path": "golang.org/x/net/idna",
-			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
-			"revisionTime": "2016-09-11T09:39:33Z"
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
+		},
+		{
+			"checksumSHA1": "RkU5lZBX/UA0RorQ0a68/sq8dPQ=",
+			"path": "golang.org/x/net/internal/timeseries",
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
 		},
 		{
 			"checksumSHA1": "UOJDYDq9dPMJ3Re3Dc9vvbi+UI0=",
 			"path": "golang.org/x/net/lex/httplex",
-			"revision": "6d3beaea10370160dea67f5c9327ed791afd5389",
-			"revisionTime": "2016-09-11T09:39:33Z"
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
 		},
 		{
-			"checksumSHA1": "zQ1i10+VxW8igU3Au7LskGPsswU=",
+			"checksumSHA1": "NbwrDuPiGQNMQbrIgzNhKM6ip+4=",
+			"path": "golang.org/x/net/trace",
+			"revision": "cfae461cedfdcab6e261a26eb77db53695623303",
+			"revisionTime": "2016-12-13T01:09:39Z"
+		},
+		{
+			"checksumSHA1": "3iUe/gp8vtun+6W5fHXLwT8rWSs=",
+			"path": "golang.org/x/oauth2",
+			"revision": "96382aa079b72d8c014eb0c50f6c223d1e6a2de0",
+			"revisionTime": "2016-12-13T06:27:07Z"
+		},
+		{
+			"checksumSHA1": "uZtSebjJCcS4Wpq6CuX3ZR021mI=",
+			"path": "golang.org/x/oauth2/google",
+			"revision": "96382aa079b72d8c014eb0c50f6c223d1e6a2de0",
+			"revisionTime": "2016-12-13T06:27:07Z"
+		},
+		{
+			"checksumSHA1": "pX0l3rObYsCBfKzCFMAgDr5cSZw=",
+			"path": "golang.org/x/oauth2/internal",
+			"revision": "96382aa079b72d8c014eb0c50f6c223d1e6a2de0",
+			"revisionTime": "2016-12-13T06:27:07Z"
+		},
+		{
+			"checksumSHA1": "z2RfcWtCJ4iOnUAVwD0CkT/kRrU=",
+			"path": "golang.org/x/oauth2/jws",
+			"revision": "96382aa079b72d8c014eb0c50f6c223d1e6a2de0",
+			"revisionTime": "2016-12-13T06:27:07Z"
+		},
+		{
+			"checksumSHA1": "0ZGHoy6JS3QaTrvzq4J5MFCmOrk=",
+			"path": "golang.org/x/oauth2/jwt",
+			"revision": "96382aa079b72d8c014eb0c50f6c223d1e6a2de0",
+			"revisionTime": "2016-12-13T06:27:07Z"
+		},
+		{
+			"checksumSHA1": "N4WObJwRFBC6QDe67fHtXLnAAB4=",
+			"path": "golang.org/x/sync/errgroup",
+			"revision": "450f422ab23cf9881c94e2db30cac0eb1b7cf80c",
+			"revisionTime": "2016-12-05T22:39:15Z"
+		},
+		{
+			"checksumSHA1": "oCUhDz8Xf2yS+bNjZ/n+Vu5zm3E=",
 			"path": "golang.org/x/sys/unix",
-			"revision": "8f0908ab3b2457e2e15403d3697c9ef5cb4b57a9",
-			"revisionTime": "2016-09-14T20:33:16Z"
+			"revision": "478fcf54317e52ab69f40bb4c7a1520288d7f7ea",
+			"revisionTime": "2016-12-05T15:46:50Z"
 		},
 		{
-			"checksumSHA1": "YzHkxW3fGe5Oc5AVatDNn1g5Ung=",
+			"checksumSHA1": "kv3jbPJGCczHVQ7g51am1MxlD1c=",
+			"path": "golang.org/x/text/internal/gen",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "ag7y2tiDc1Yx4fxBrA/CuwKZptg=",
+			"path": "golang.org/x/text/internal/testtext",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "gKFK/QdtO0abkFjDiEyOBgLxWoM=",
+			"path": "golang.org/x/text/internal/triegen",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "GQ0REMGv0GeUMa3mjH2n5xw2UhY=",
+			"path": "golang.org/x/text/internal/ucd",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "LXVplVWZWrHA8yelCVlNvlcwIMs=",
+			"path": "golang.org/x/text/transform",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "Ysu8WjwCUqUtLY5ngP3t+TRBoqg=",
+			"path": "golang.org/x/text/unicode/cldr",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "n4n4z6+wLrs/vWj2BvfUz5DBY2c=",
+			"path": "golang.org/x/text/unicode/norm",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "qkXaWdEA3muB+CiGqFxqeL1NXKE=",
+			"path": "golang.org/x/text/width",
+			"revision": "47a200a05c8b3fd1b698571caecbb68beb2611ec",
+			"revisionTime": "2016-11-30T21:25:21Z"
+		},
+		{
+			"checksumSHA1": "UU1XOxBqPJ1MTDDpC+iW3OMqiJY=",
+			"path": "google.golang.org/appengine",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "0nDJO6rXw3Zn5px456bYaJnhfWQ=",
+			"path": "google.golang.org/appengine/internal",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "x6Thdfyasqd68dWZWqzWWeIfAfI=",
+			"path": "google.golang.org/appengine/internal/app_identity",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "TsNO8P0xUlLNyh3Ic/tzSp/fDWM=",
+			"path": "google.golang.org/appengine/internal/base",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "5QsV5oLGSfKZqTCVXP6NRz5T4Tw=",
+			"path": "google.golang.org/appengine/internal/datastore",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "Gep2T9zmVYV8qZfK2gu3zrmG6QE=",
+			"path": "google.golang.org/appengine/internal/log",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "eLZVX1EHLclFtQnjDIszsdyWRHo=",
+			"path": "google.golang.org/appengine/internal/modules",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "a1XY7rz3BieOVqVI2Et6rKiwQCk=",
+			"path": "google.golang.org/appengine/internal/remote_api",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "QtAbHtHmDzcf6vOV9eqlCpKgjiw=",
+			"path": "google.golang.org/appengine/internal/urlfetch",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "akOV9pYnCbcPA8wJUutSQVibdyg=",
+			"path": "google.golang.org/appengine/urlfetch",
+			"revision": "ca59ef35f409df61fa4a5f8290ff289b37eccfb8",
+			"revisionTime": "2016-11-15T22:01:06Z"
+		},
+		{
+			"checksumSHA1": "5PAIWw8TIHMTXjCcnhA9xEgYKMs=",
+			"path": "google.golang.org/grpc",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "08icuA15HRkdYCt6H+Cs90RPQsY=",
+			"path": "google.golang.org/grpc/codes",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "GCKxN7Ss5Q3oOOb4L+jC43MjuLQ=",
+			"path": "google.golang.org/grpc/credentials",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "3Lt5hNAG8qJAYSsNghR5uA1zQns=",
+			"path": "google.golang.org/grpc/grpclog",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "T3Q0p8kzvXFnRkMaK/G8mCv6mc0=",
+			"path": "google.golang.org/grpc/internal",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "sBcum/EfERLfl8KrUWA3x5NGrGA=",
+			"path": "google.golang.org/grpc/metadata",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "4GSUFhOQ0kdFlBH4D5OTeKy78z0=",
+			"path": "google.golang.org/grpc/naming",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "3RRoLeH6X2//7tVClOVzxW2bY+E=",
+			"path": "google.golang.org/grpc/peer",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "Sfy2pgcYd6jyaOYpFu33QbKyP4Q=",
+			"path": "google.golang.org/grpc/stats",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "tjOXEB1rZdo0gSzrAy1apgF8ZDs=",
+			"path": "google.golang.org/grpc/stats/grpc_testing",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "N0TftT6/CyWqp6VRi2DqDx60+Fo=",
+			"path": "google.golang.org/grpc/tap",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "mCB3odJgVvjmrCWkgNmyN8MLbCo=",
+			"path": "google.golang.org/grpc/test/codec_perf",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "ZZ8MgeqdxiDAznGgAzIUIerg9Jw=",
+			"path": "google.golang.org/grpc/transport",
+			"revision": "8712952b7d646dbbbc6fb73a782174f3115060f3",
+			"revisionTime": "2016-12-09T21:45:00Z"
+		},
+		{
+			"checksumSHA1": "538I8ghUdvZa25NxgMUDpq14Qic=",
 			"path": "gopkg.in/check.v1",
-			"revision": "4f90aeace3a26ad7021961c297b22c42160c7b25",
-			"revisionTime": "2016-01-05T16:49:36Z"
+			"revision": "20d25e2804050c1cd24a7eea1e7a6447dd0e74ec",
+			"revisionTime": "2016-12-08T18:13:25Z"
 		},
 		{
 			"checksumSHA1": "puukSI4sk1NrZynJws6JPuOUnj8=",
@@ -453,730 +879,1107 @@
 			"revisionTime": "2014-09-24T16:16:07Z"
 		},
 		{
-			"checksumSHA1": "K21POG6vpC/NAie+NRLnsTAiMS8=",
+			"checksumSHA1": "lJHPwsxC3Xws7TIRUrB3Ki5HqkU=",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "31c299268d302dd0aa9a0dcf765a3d58971ac83f",
-			"revisionTime": "2016-09-12T16:56:03Z"
-		},
-		{
-			"checksumSHA1": "LpbaHGD9HacI83k5aza5v5dCJuQ=",
-			"path": "k8s.io/client-go/1.4/discovery",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "LHEnQDTPkHXiwuX4O+LUtVGO16U=",
-			"path": "k8s.io/client-go/1.4/kubernetes",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "YJ5q8Yjcrar5DiBqPZ7zIALjmBs=",
-			"path": "k8s.io/client-go/1.4/kubernetes/typed/authorization/v1beta1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "T/mJok0nYog1B+XW/HDw3qWnuRY=",
-			"path": "k8s.io/client-go/1.4/kubernetes/typed/autoscaling/v1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "qyKWDN5HScO/E5u4gcbNh067UCc=",
-			"path": "k8s.io/client-go/1.4/kubernetes/typed/batch/v1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "bCCkruxIgzkPmKjM4pjvdBpcCkw=",
-			"path": "k8s.io/client-go/1.4/kubernetes/typed/core/v1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "E4mRmLxUTWUFWluR7vjYiL4niJ0=",
-			"path": "k8s.io/client-go/1.4/kubernetes/typed/extensions/v1beta1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "6K9ulOeiLqY0WZcBEXecbJLl5JE=",
-			"path": "k8s.io/client-go/1.4/kubernetes/typed/policy/v1alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "Be3e1If1BP9ifh6aJ1I4Hv8bqrI=",
-			"path": "k8s.io/client-go/1.4/pkg/api",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "6whIXnnUL2Rwc1nbjlFmXWpW9H8=",
-			"path": "k8s.io/client-go/1.4/pkg/api/endpoints",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "UTSvwPGnPorqeFnfpIoH0wOtv2Q=",
-			"path": "k8s.io/client-go/1.4/pkg/api/errors",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "bRgvPT9o0l0VrheobLZujxUWdBQ=",
-			"path": "k8s.io/client-go/1.4/pkg/api/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "E/qSJk55vUWHYE+wSEztfA/mKJY=",
-			"path": "k8s.io/client-go/1.4/pkg/api/meta",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "mkmTzS9JgobXl5uUnhxlHeqz8yo=",
-			"path": "k8s.io/client-go/1.4/pkg/api/meta/metatypes",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "k/Rd2pFvJAks60Newgfif4oECXU=",
-			"path": "k8s.io/client-go/1.4/pkg/api/pod",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "C3eVzDdMP5HfkgmBBOEJ3XYRadQ=",
-			"path": "k8s.io/client-go/1.4/pkg/api/resource",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "tKbC92KOB/P1ZMfNf0S6q64S1G4=",
-			"path": "k8s.io/client-go/1.4/pkg/api/service",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "lfM12jHrwv0it6XmVKXeg7SWl8Q=",
-			"path": "k8s.io/client-go/1.4/pkg/api/testapi",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "GecSyt628xX/Rr4n/dXO6dgbADc=",
-			"path": "k8s.io/client-go/1.4/pkg/api/unversioned",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "VFWvcdBVutOMS9FAOIy+rfxlxA4=",
-			"path": "k8s.io/client-go/1.4/pkg/api/unversioned/validation",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "gM61gRVSIlPCsce5L72HqnFvVdQ=",
-			"path": "k8s.io/client-go/1.4/pkg/api/util",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "GVirpPqXXNsBniN4qMKlg9IsS48=",
-			"path": "k8s.io/client-go/1.4/pkg/api/v1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "90hc0UkWR5NfSbTTa9e70CwZRAY=",
-			"path": "k8s.io/client-go/1.4/pkg/api/validation",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "sHp3hinCdFt9HvxriPoTFmXuVn0=",
-			"path": "k8s.io/client-go/1.4/pkg/apimachinery",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "R/1RJ6+gJMRjDqc4lrgu4PfolWA=",
-			"path": "k8s.io/client-go/1.4/pkg/apimachinery/registered",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "zNTX0hDY1YSCZdHc5FpTZ3Hz7nw=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/apps",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "9sWnqQt5fnAwtjM1FWq9FKJHK2Y=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/apps/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "mNCLMqpkLvTEhp2rCH/h6mtKai8=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/apps/v1alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "CqfqLzRQtwFuSuFippZih3f9Qmg=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/authentication",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "ICUMHS7e94xhlHlJ43sERWC3hy4=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/authentication/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "vdghPaDTJoG4NlxkT3urzOzkGGE=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/authentication/v1beta1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "LFWZYAeIDjHDsIcqwcm9ENM9DPY=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/authorization",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "sFjZyEYFUPKdGXubr0xsAwRVqvw=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/authorization/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "IDQxLkJa0vtksV2R69p0Cv+qVqE=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/authorization/v1beta1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "xthoFmzT2V/sb0suWfPBb/LUoRE=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/autoscaling",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "87MKv+HO03fv46Po2OODzqMT+lI=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/autoscaling/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "7mdWT+UC93tDmVYjYL2caubpttM=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/autoscaling/v1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "0ZdGRxuciuCU0u8qZ58HNZt9fXs=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/batch",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "nIQwZu6dj9L/TQw7txJ64u0i05M=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/batch/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "+eG6Be7KeT5OS22acc+R7/8P5tA=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/batch/v1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "VVHYQ7w9pIHZeEPJ+i6oATJ/i14=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/batch/v2alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "cXR6RBo4BSGNqyo+mNcLAo5nE68=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/certificates",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "ra5TbioUltyrnQpg7BT/eXdoUMU=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/certificates/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "P6C3e8L/BeLQ0cwW8pICoZIx1Kg=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/certificates/v1alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "khc99JhyQhrpfzlAytbqSgSrKoI=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/componentconfig",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "r59+ZJJUYZAvHy6HG3wSHZTAetI=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/componentconfig/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "nVCvUiJTLVuntdCK9uabmgKEv4A=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/componentconfig/v1alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "FKh/VnshCZbCGLv0h6xY9TgaQec=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/extensions",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "+AnVqO2QN6lTE2e47bEQJxjs+k0=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/extensions/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "Uz4f3f/VHHwXVR5kYf9uh8qGN8o=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/extensions/v1beta1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "cSiFPgZmmOctySNz9nWhc67qEaM=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/imagepolicy",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "a+tvWO3/OEedQX9mJUQDVE+QSio=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/imagepolicy/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "YpOBJtUsXbXYsVMF1iDLI7wFFdk=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/imagepolicy/v1alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "9j/R5V4CR1X8ZlrMaBZ6FkiZ+e8=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/policy",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "ymvjH5FxL8nDHWFdbTdBYBtb0IM=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/policy/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "xQ5XOBBuqfKH+maf3WJQI2y7Np0=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/policy/v1alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "61/K0ec5vJz1frXWMVc/XFq6n8s=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/rbac",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "ffypBVscuej3WxQ3/dopDchNwgE=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/rbac/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "gQah1Y74y2+wLepaoFUcD+4iyYU=",
-			"path": "k8s.io/client-go/1.4/pkg/apis/rbac/v1alpha1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "rNuAgLiP5Ju0p9aTFJDYj6vBpfE=",
-			"path": "k8s.io/client-go/1.4/pkg/auth/user",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "DsLfLmarj7lv0hLZt5HSHOVtKXY=",
-			"path": "k8s.io/client-go/1.4/pkg/capabilities",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "TNizJbOxKVDFWKQh38cx+Fnf9sE=",
-			"path": "k8s.io/client-go/1.4/pkg/conversion",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "SNkQclx4MTM+/e/ky3hjyvFhm8Q=",
-			"path": "k8s.io/client-go/1.4/pkg/conversion/queryparams",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "On4N5xL/O0l42Kv/oLpMonvT6dE=",
-			"path": "k8s.io/client-go/1.4/pkg/federation/apis/federation",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "ChkBQBftScL3cAh7yGiJbgiijFk=",
-			"path": "k8s.io/client-go/1.4/pkg/federation/apis/federation/install",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "qkrTaOuCpZ3coT6f6OER2Hl43rE=",
-			"path": "k8s.io/client-go/1.4/pkg/federation/apis/federation/v1beta1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "GZ99BhZpcBiWIludtXXNguR6GLg=",
-			"path": "k8s.io/client-go/1.4/pkg/fields",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "U2R34RiFzee1SMMwWDyfW9zaLxI=",
-			"path": "k8s.io/client-go/1.4/pkg/kubelet/qos",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "fbnWy1dfAZFo/MGIkYbhddPWZdE=",
-			"path": "k8s.io/client-go/1.4/pkg/kubelet/types",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "JRnfOUtjqaFXA8JGzCcn57intX8=",
-			"path": "k8s.io/client-go/1.4/pkg/labels",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "C2OGB92g4KRf3vyTYfrdUq/x9/I=",
-			"path": "k8s.io/client-go/1.4/pkg/master/ports",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "CnJ/y2qfWFMaZfhkAz5BLrMpz68=",
-			"path": "k8s.io/client-go/1.4/pkg/runtime",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "8vlT7wE7H9OJyzAFNP/QcVPwYfA=",
-			"path": "k8s.io/client-go/1.4/pkg/runtime/serializer",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "lXfOEHe+0MAOlGfp3eIj/4iqg6k=",
-			"path": "k8s.io/client-go/1.4/pkg/runtime/serializer/json",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "+2XML+TSQlfmWw+O72K5NJgNE3A=",
-			"path": "k8s.io/client-go/1.4/pkg/runtime/serializer/protobuf",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "ypQP3jmUO9xLRBcqOJh/AO/cSKA=",
-			"path": "k8s.io/client-go/1.4/pkg/runtime/serializer/recognizer",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "SkxnIa/cAG99h0ITZREIkOklNwU=",
-			"path": "k8s.io/client-go/1.4/pkg/runtime/serializer/streaming",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "e9lUnKa5JP9k9ZmI2sPuJobZwuQ=",
-			"path": "k8s.io/client-go/1.4/pkg/runtime/serializer/versioning",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "xe4xYwtwa+K6Pjza0LQlTok6pME=",
-			"path": "k8s.io/client-go/1.4/pkg/security/apparmor",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "NgGPhzlFczyH2AavM6RfnLrQZpU=",
-			"path": "k8s.io/client-go/1.4/pkg/selection",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "Yx4b42jVgPLSLD7579Rqg5nVJ3k=",
-			"path": "k8s.io/client-go/1.4/pkg/third_party/forked/golang/reflect",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "nRPLcmzuzSAdGO+wqU5lX6l/oec=",
-			"path": "k8s.io/client-go/1.4/pkg/types",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "mphuZJD+1GuJYTJdDr6+zWbODAs=",
-			"path": "k8s.io/client-go/1.4/pkg/util",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "+wnCbOQUq2I9R5dL5Qxc7uqrLoc=",
-			"path": "k8s.io/client-go/1.4/pkg/util/clock",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "v5pSTVOmbBzxH0nilub+R0IroNE=",
-			"path": "k8s.io/client-go/1.4/pkg/util/config",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "byQihmJdoztClrAbZKOvajvNpic=",
-			"path": "k8s.io/client-go/1.4/pkg/util/crypto",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "xAnQ/acKilVMnZcp2PfbDiHbIDA=",
-			"path": "k8s.io/client-go/1.4/pkg/util/diff",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "N78kSfcKbh0jrFmIWpJD+76j29U=",
-			"path": "k8s.io/client-go/1.4/pkg/util/errors",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "JDz2qo5AH/UimnnbPSTjzGGX4LI=",
-			"path": "k8s.io/client-go/1.4/pkg/util/flowcontrol",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "1rkDcU7L1cna1uxrek21U5awEJg=",
-			"path": "k8s.io/client-go/1.4/pkg/util/framer",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "WUK0YkoM2uoDAhhEZ0+lWcRmCSs=",
-			"path": "k8s.io/client-go/1.4/pkg/util/hash",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "dLvmFVHXD0oEzEhXQjuAaPqIeeM=",
-			"path": "k8s.io/client-go/1.4/pkg/util/homedir",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "jpBezqAZwDJ3VhBDhaU810qaw6k=",
-			"path": "k8s.io/client-go/1.4/pkg/util/httpstream",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "p1Ayc8z1eYs9Ak4pacMytQI0TvE=",
-			"path": "k8s.io/client-go/1.4/pkg/util/integer",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "5WJdMGFWdXa0Wa/MsGnrpePUl+U=",
-			"path": "k8s.io/client-go/1.4/pkg/util/intstr",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "5eJzfiDmuUN5XIntjPhZyjAaSAQ=",
-			"path": "k8s.io/client-go/1.4/pkg/util/json",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "BW8SzA/2mC9XCziS3UX5aryLHSs=",
-			"path": "k8s.io/client-go/1.4/pkg/util/labels",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "bLm6QaGC144QfXbjCOkXF6ll198=",
-			"path": "k8s.io/client-go/1.4/pkg/util/net",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "nc9HZDnHc7XgrYaPcuMNdbHMtwE=",
-			"path": "k8s.io/client-go/1.4/pkg/util/net/sets",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "AxA+jaHPck3rVqXA9+rpxSKF6ig=",
-			"path": "k8s.io/client-go/1.4/pkg/util/parsers",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "xYfseBN9hky3NMc/fYu1Bca25z4=",
-			"path": "k8s.io/client-go/1.4/pkg/util/rand",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "T/fREIF2lo/iCc0gUtZxRdEIUOA=",
-			"path": "k8s.io/client-go/1.4/pkg/util/runtime",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "CMlEQHtXcO+Wqp0eGlmhgsfDCP0=",
-			"path": "k8s.io/client-go/1.4/pkg/util/sets",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "C2Q1yRIUrnoQdNqlQhPS+tyrvHE=",
-			"path": "k8s.io/client-go/1.4/pkg/util/testing",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "eQb23MSjdK//6Yb82YB30j0MLw8=",
-			"path": "k8s.io/client-go/1.4/pkg/util/uuid",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "YH1XX914MKo71yRxNPM4aOcTGgA=",
-			"path": "k8s.io/client-go/1.4/pkg/util/validation",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "/jqBMkr4ezyXJDSOFXI3qdMLI1A=",
-			"path": "k8s.io/client-go/1.4/pkg/util/validation/field",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "x8UOJEn3tOx2vLxtzvoo4a5Htqg=",
-			"path": "k8s.io/client-go/1.4/pkg/util/wait",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "NzftvrCMFBa/NEuw+vR4l5S9OQ0=",
-			"path": "k8s.io/client-go/1.4/pkg/util/yaml",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "SMoX2/yP+9uWj63zi59fFCyI4v8=",
-			"path": "k8s.io/client-go/1.4/pkg/version",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "caihJivdOizvv2ILuicWntsQ4Rc=",
-			"path": "k8s.io/client-go/1.4/pkg/watch",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "JInZpHc05yCvUJJ7C++V70c9vjo=",
-			"path": "k8s.io/client-go/1.4/pkg/watch/versioned",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "8w/+DhhSHKNfu7pClExfKyX/cBI=",
-			"path": "k8s.io/client-go/1.4/rest",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "0tXFrwokCVgOZwh99k3CZlcMC6Q=",
-			"path": "k8s.io/client-go/1.4/tools/auth",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "tqFHWu/J51nWJKDvaBA7iShn2pA=",
-			"path": "k8s.io/client-go/1.4/tools/clientcmd",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "wMu6DwgA0VSyPRO7rvdzg+NmhjY=",
-			"path": "k8s.io/client-go/1.4/tools/clientcmd/api",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "QERmUdXk/vlvx2dAw+RgW3UY8lo=",
-			"path": "k8s.io/client-go/1.4/tools/clientcmd/api/latest",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "biYigSMVVT9ipIWcf+hENnDasIw=",
-			"path": "k8s.io/client-go/1.4/tools/clientcmd/api/v1",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "Krb+RRSWBlRPCyJrJMjKwQFB4EU=",
-			"path": "k8s.io/client-go/1.4/tools/metrics",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
-		},
-		{
-			"checksumSHA1": "ZrLpM/Ou/hw4NHVKx2azaR/3v8w=",
-			"path": "k8s.io/client-go/1.4/transport",
-			"revision": "93fcd402979cfad8a7151f96e016416947c6a3cb",
-			"revisionTime": "2016-09-08T15:44:51Z"
+			"revision": "a5b47d31c556af34a302ce5d659e6fea44d90de0",
+			"revisionTime": "2016-09-28T15:37:09Z"
+		},
+		{
+			"checksumSHA1": "1xrXI7Cw60rHrATp6hmyQalOE8M=",
+			"origin": "github.com/kubernetes/client-go/1.5/discovery",
+			"path": "k8s.io/client-go/1.5/discovery",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "S+OzpkipMb46LGZoWuveqSLAcoM=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes",
+			"path": "k8s.io/client-go/1.5/kubernetes",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "yCBn8ig1TUMrk+ljtK0nDr7E5Vo=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/apps/v1alpha1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/apps/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "ZRnUz5NrpvJsXAjtnRdEv5UYhSI=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/authentication/v1beta1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/authentication/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "TY55Np20olmPMzXgfVlIUIyqv04=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/authorization/v1beta1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/authorization/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "FRByJsFff/6lPH20FtJPaK1NPWI=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/autoscaling/v1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/autoscaling/v1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "3Cy2as7HnQ2FDcvpNbatpFWx0P4=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/batch/v1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/batch/v1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "RUKywApIbSLLsfkYxXzifh7HIvs=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/certificates/v1alpha1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/certificates/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "4+Lsxu+sYgzsS2JOHP7CdrZLSKc=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/core/v1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/core/v1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "H8jzevN03YUfmf2krJt0qj2P9sU=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/extensions/v1beta1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/extensions/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "hrpA6xxtwj3oMcQbFxI2cDhO2ZA=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/policy/v1alpha1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/policy/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "B2+F12NeMwrOHvHK2ALyEcr3UGA=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/rbac/v1alpha1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/rbac/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "h2eSNUym87RWPlez7UKujShwrUQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/kubernetes/typed/storage/v1beta1",
+			"path": "k8s.io/client-go/1.5/kubernetes/typed/storage/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "+oIykJ3A0wYjAWbbrGo0jNnMLXw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api",
+			"path": "k8s.io/client-go/1.5/pkg/api",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "UsUsIdhuy5Ej2vI0hbmSsrimoaQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/errors",
+			"path": "k8s.io/client-go/1.5/pkg/api/errors",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "Eo6LLHFqG6YznIAKr2mVjuqUj6k=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/install",
+			"path": "k8s.io/client-go/1.5/pkg/api/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "dYznkLcCEai21z1dX8kZY7uDsck=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/meta",
+			"path": "k8s.io/client-go/1.5/pkg/api/meta",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "b06esG4xMj/YNFD85Lqq00cx+Yo=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/meta/metatypes",
+			"path": "k8s.io/client-go/1.5/pkg/api/meta/metatypes",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "L9svak1yut0Mx8r9VLDOwpqZzBk=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/resource",
+			"path": "k8s.io/client-go/1.5/pkg/api/resource",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "pmuovFVMEefTTHteivqKQ1zHHGs=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/testapi",
+			"path": "k8s.io/client-go/1.5/pkg/api/testapi",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "m7jGshKDLH9kdokfa6MwAqzxRQk=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/unversioned",
+			"path": "k8s.io/client-go/1.5/pkg/api/unversioned",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "iI6s5WAexr1PEfqrbvuscB+oVik=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/v1",
+			"path": "k8s.io/client-go/1.5/pkg/api/v1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "ikac34qI/IkTWHnfi8pPl9irPyo=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/api/validation/path",
+			"path": "k8s.io/client-go/1.5/pkg/api/validation/path",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "MJyygSPp8N6z+7SPtcROz4PEwas=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apimachinery",
+			"path": "k8s.io/client-go/1.5/pkg/apimachinery",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "EGb4IcSTQ1VXCmX0xcyG5GpWId8=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apimachinery/announced",
+			"path": "k8s.io/client-go/1.5/pkg/apimachinery/announced",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "vhSyuINHQhCsDKTyBmvJT1HzDHI=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apimachinery/registered",
+			"path": "k8s.io/client-go/1.5/pkg/apimachinery/registered",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "rXeBnwLg8ZFe6m5/Ki7tELVBYDk=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/apps",
+			"path": "k8s.io/client-go/1.5/pkg/apis/apps",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "KzHaG858KV1tBh5cuLInNcm+G5s=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/apps/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/apps/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "fynWdchlRbPaxuST2oGDKiKLTqE=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/apps/v1alpha1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/apps/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "hreIYssoH4Ef/+Aglpitn3GNLR4=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/authentication",
+			"path": "k8s.io/client-go/1.5/pkg/apis/authentication",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "EgUqJH4CqB9vXVg6T8II2OEt5LE=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/authentication/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/authentication/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "Z3DKgomzRPGcBv/8hlL6pfnIpXI=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/authentication/v1beta1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/authentication/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "GpuScB2Z+NOT4WIQg1mVvVSDUts=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/authorization",
+			"path": "k8s.io/client-go/1.5/pkg/apis/authorization",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "+u3UD+HY9lBH+PFi/2B4W564JEw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/authorization/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/authorization/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "zIFzgWjmlWNLHGHMpCpDCvoLtKY=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/authorization/v1beta1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/authorization/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "tdpzQFQyVkt5kCLTvtKTVqT+maE=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/autoscaling",
+			"path": "k8s.io/client-go/1.5/pkg/apis/autoscaling",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "nb6LbYGS5tv8H8Ovptg6M7XuDZ4=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/autoscaling/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/autoscaling/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "DNb1/nl/5RDdckRrJoXBRagzJXs=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/autoscaling/v1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/autoscaling/v1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "4bLhH2vNl5l4Qp6MjLhWyWVAPE0=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/batch",
+			"path": "k8s.io/client-go/1.5/pkg/apis/batch",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "RpAAEynmxlvOlLLZK1KEUQRnYzk=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/batch/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/batch/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "uWJ2BHmjL/Gq4FFlNkqiN6vvPyM=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/batch/v1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/batch/v1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "mHWt/p724dKeP1vqLtWQCye7zaE=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/batch/v2alpha1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/batch/v2alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "6dJ1dGfXkB3A42TOtMaY/rvv4N8=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/certificates",
+			"path": "k8s.io/client-go/1.5/pkg/apis/certificates",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "Bkrhm6HbFYANwtzUE8eza9SWBk0=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/certificates/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/certificates/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "nRRPIBQ5O3Ad24kscNtK+gPC+fk=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/certificates/v1alpha1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/certificates/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "OOgJwYa8bDGp7t7Ftpg3Y1oBVYU=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/componentconfig",
+			"path": "k8s.io/client-go/1.5/pkg/apis/componentconfig",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "oTJaUzX4DDVqtkHFsADjl8ckl0c=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/componentconfig/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/componentconfig/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "+UefYKto0+iFR0PNUqrafo6Z8EI=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/componentconfig/v1alpha1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/componentconfig/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "KUMhoaOg9GXHN/aAVvSLO18SgqU=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/extensions",
+			"path": "k8s.io/client-go/1.5/pkg/apis/extensions",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "eSo2VhNAYtesvmpEPqn05goW4LY=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/extensions/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/extensions/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "DunWIPrCC5iGMWzkaaugMOxD+hg=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/extensions/v1beta1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/extensions/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "xU1Ojzzra08MszjmjKQfNiSL9rg=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/imagepolicy",
+			"path": "k8s.io/client-go/1.5/pkg/apis/imagepolicy",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "qCT2ejOoGwdLl+dyMuTtLGVCgVc=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/imagepolicy/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/imagepolicy/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "d4aS2haoem67GcExERvlbGLJ+S0=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/imagepolicy/v1alpha1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/imagepolicy/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "rVGYi2ko0E7vL5OZSMYX+NAGPYw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/policy",
+			"path": "k8s.io/client-go/1.5/pkg/apis/policy",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "llJHd2H0LzABGB6BcletzIHnexo=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/policy/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/policy/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "j44bqyY13ldnuCtysYE8nRkMD7o=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/policy/v1alpha1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/policy/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "vT7rFxowcKMTYc55mddePqUFRgE=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/rbac",
+			"path": "k8s.io/client-go/1.5/pkg/apis/rbac",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "r1MzUXsG+Zyn30aU8I5R5dgrJPA=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/rbac/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/rbac/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "aNfO8xn8VDO3fM9CpVCe6EIB+GA=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/rbac/v1alpha1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/rbac/v1alpha1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "rQCxrbisCXmj2wymlYG63kcTL9I=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/storage",
+			"path": "k8s.io/client-go/1.5/pkg/apis/storage",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "wZyxh5nt5Eh6kF7YNAIYukKWWy0=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/storage/install",
+			"path": "k8s.io/client-go/1.5/pkg/apis/storage/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "P8ANOt/I4Cs3QtjVXWmDA/gpQdg=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/apis/storage/v1beta1",
+			"path": "k8s.io/client-go/1.5/pkg/apis/storage/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "qnVPwzvNLz2mmr3BXdU9qIhQXXU=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/auth/user",
+			"path": "k8s.io/client-go/1.5/pkg/auth/user",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "KrIchxhapSs242yAy8yrTS1XlZo=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/conversion",
+			"path": "k8s.io/client-go/1.5/pkg/conversion",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "weZqKFcOhcnF47eDDHXzluCKSF0=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/conversion/queryparams",
+			"path": "k8s.io/client-go/1.5/pkg/conversion/queryparams",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "NoepkWV04UFj962ii5tOKhQ8z1A=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/federation/apis/federation",
+			"path": "k8s.io/client-go/1.5/pkg/federation/apis/federation",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "qnzLWMyZ4L/YMZHpsnrmTygGFds=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/federation/apis/federation/install",
+			"path": "k8s.io/client-go/1.5/pkg/federation/apis/federation/install",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "s093o9JsJR/QS9vHNFjX0pid5+8=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/federation/apis/federation/v1beta1",
+			"path": "k8s.io/client-go/1.5/pkg/federation/apis/federation/v1beta1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "T3EMfyXZX5939/OOQ1JU+Nmbk4k=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/fields",
+			"path": "k8s.io/client-go/1.5/pkg/fields",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "2v11s3EBH8UBl2qfImT29tQN2kM=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/genericapiserver/openapi/common",
+			"path": "k8s.io/client-go/1.5/pkg/genericapiserver/openapi/common",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "GvBlph6PywK3zguou/T9kKNNdoQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/labels",
+			"path": "k8s.io/client-go/1.5/pkg/labels",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "Vtrgy827r0rWzIAgvIWY4flu740=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/runtime",
+			"path": "k8s.io/client-go/1.5/pkg/runtime",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "SEcZqRATexhgHvDn+eHvMc07UJs=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/runtime/serializer",
+			"path": "k8s.io/client-go/1.5/pkg/runtime/serializer",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "qzYKG9YZSj8l/W1QVTOrGAry/BM=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/runtime/serializer/json",
+			"path": "k8s.io/client-go/1.5/pkg/runtime/serializer/json",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "F7h+8zZ0JPLYkac4KgSVljguBE4=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/runtime/serializer/protobuf",
+			"path": "k8s.io/client-go/1.5/pkg/runtime/serializer/protobuf",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "CvySOL8C85e3y7EWQ+Au4cwUZJM=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/runtime/serializer/recognizer",
+			"path": "k8s.io/client-go/1.5/pkg/runtime/serializer/recognizer",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "eCitoKeIun+lJzYFhAfdSIIicSM=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/runtime/serializer/streaming",
+			"path": "k8s.io/client-go/1.5/pkg/runtime/serializer/streaming",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "kVWvZuLGltJ4YqQsiaCLRRLDDK0=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/runtime/serializer/versioning",
+			"path": "k8s.io/client-go/1.5/pkg/runtime/serializer/versioning",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "m51+LAeQ9RK1KHX+l2iGcwbVCKs=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/selection",
+			"path": "k8s.io/client-go/1.5/pkg/selection",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "dp4IWcC3U6a0HeOdVCDQWODWCbw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/third_party/forked/golang/reflect",
+			"path": "k8s.io/client-go/1.5/pkg/third_party/forked/golang/reflect",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "ER898XJD1ox4d71gKZD8TLtTSpM=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/types",
+			"path": "k8s.io/client-go/1.5/pkg/types",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "BVdXtnLDlmBQksRPfHOIG+qdeVg=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util",
+			"path": "k8s.io/client-go/1.5/pkg/util",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "nnh8Sa4dCupxRI4bbKaozGp1d/A=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/cert",
+			"path": "k8s.io/client-go/1.5/pkg/util/cert",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "S32d5uduNlwouM8+mIz+ALpliUQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/clock",
+			"path": "k8s.io/client-go/1.5/pkg/util/clock",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "xlp2KOYHM6ck9x1ifOfT1iZ/TXc=",
+			"path": "k8s.io/client-go/1.5/pkg/util/config",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "LFneuXipUCtm3G4LNeiLWkn8EvI=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/diff",
+			"path": "k8s.io/client-go/1.5/pkg/util/diff",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "Y6rWC0TUw2/uUeUjJ7kazyEUzBQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/errors",
+			"path": "k8s.io/client-go/1.5/pkg/util/errors",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "C7IfEAdCOePw3/IraaZCNXuYXLw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/flowcontrol",
+			"path": "k8s.io/client-go/1.5/pkg/util/flowcontrol",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "EuslQHnhBSRXaWimYqLEqhMPV48=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/framer",
+			"path": "k8s.io/client-go/1.5/pkg/util/framer",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "Sbkot7HTnigUdo1Y0er9TQtgNz0=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/homedir",
+			"path": "k8s.io/client-go/1.5/pkg/util/homedir",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "sv7N7tNEpAgeRFTNq1HlzDlECQM=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/httpstream",
+			"path": "k8s.io/client-go/1.5/pkg/util/httpstream",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "ByO18NbZwiifFr8qtLyfJAHXguA=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/integer",
+			"path": "k8s.io/client-go/1.5/pkg/util/integer",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "ww+RfsoIlUBDwThg2oqC5QVz33Y=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/intstr",
+			"path": "k8s.io/client-go/1.5/pkg/util/intstr",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "7E8f8dLlXW7u6r9sggMjvB4HEiw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/json",
+			"path": "k8s.io/client-go/1.5/pkg/util/json",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "d0pFZxMJG9j95acNmaIM1l+X+QU=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/labels",
+			"path": "k8s.io/client-go/1.5/pkg/util/labels",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "wCN7u1lE+25neM9jXeI7aE8EAfk=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/net",
+			"path": "k8s.io/client-go/1.5/pkg/util/net",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "g+kBkxcb+tYmFtRRly+VE+JAIfw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/parsers",
+			"path": "k8s.io/client-go/1.5/pkg/util/parsers",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "S4wUnE5VkaWWrkLbgPL/1oNLJ4g=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/rand",
+			"path": "k8s.io/client-go/1.5/pkg/util/rand",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "8j9c2PqTKybtnymXbStNYRexRj8=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/runtime",
+			"path": "k8s.io/client-go/1.5/pkg/util/runtime",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "aAz4e8hLGs0+ZAz1TdA5tY/9e1A=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/sets",
+			"path": "k8s.io/client-go/1.5/pkg/util/sets",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "eEMw1zvI1SnCc4AS/wdEaBfRLFI=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/testing",
+			"path": "k8s.io/client-go/1.5/pkg/util/testing",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "P/fwh6QZ5tsjVyHTaASDWL3WaGs=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/uuid",
+			"path": "k8s.io/client-go/1.5/pkg/util/uuid",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "P9Bq/1qbF4SvnN9HyCTRpbUz7sQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/validation",
+			"path": "k8s.io/client-go/1.5/pkg/util/validation",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "D0JIEjlP69cuPOZEdsSKeFgsnI8=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/validation/field",
+			"path": "k8s.io/client-go/1.5/pkg/util/validation/field",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "T7ba8t8i+BtgClMgL+aMZM94fcI=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/wait",
+			"path": "k8s.io/client-go/1.5/pkg/util/wait",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "6RCTv/KDiw7as4KeyrgU3XrUSQI=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/util/yaml",
+			"path": "k8s.io/client-go/1.5/pkg/util/yaml",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "OwKlsSeKtz1FBVC9cQ5gWRL5pKc=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/version",
+			"path": "k8s.io/client-go/1.5/pkg/version",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "Oil9WGw/dODbpBopn6LWQGS3DYg=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/watch",
+			"path": "k8s.io/client-go/1.5/pkg/watch",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "r5alnRCbLaPsbTeJjjTVn/bt6uw=",
+			"origin": "github.com/kubernetes/client-go/1.5/pkg/watch/versioned",
+			"path": "k8s.io/client-go/1.5/pkg/watch/versioned",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "WIaNZl+NhGRBYlHcgVi0KvG7OdI=",
+			"origin": "github.com/kubernetes/client-go/1.5/plugin/pkg/auth/authenticator/token/oidc/testing",
+			"path": "k8s.io/client-go/1.5/plugin/pkg/auth/authenticator/token/oidc/testing",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "X1+ltyfHui/XCwDupXIf39+9gWQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/plugin/pkg/client/auth",
+			"path": "k8s.io/client-go/1.5/plugin/pkg/client/auth",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "KYy+js37AS0ZT08g5uBr1ZoMPmE=",
+			"origin": "github.com/kubernetes/client-go/1.5/plugin/pkg/client/auth/gcp",
+			"path": "k8s.io/client-go/1.5/plugin/pkg/client/auth/gcp",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "5p48l7RNuNAlOoC1KAInI8kQZpQ=",
+			"origin": "github.com/kubernetes/client-go/1.5/plugin/pkg/client/auth/oidc",
+			"path": "k8s.io/client-go/1.5/plugin/pkg/client/auth/oidc",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "hBELdE39f9+UFrSkcyJqLSLQhLo=",
+			"origin": "github.com/kubernetes/client-go/1.5/rest",
+			"path": "k8s.io/client-go/1.5/rest",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "UokJQXU+j8krBwGuS3c6RNdPdeY=",
+			"origin": "github.com/kubernetes/client-go/1.5/tools/auth",
+			"path": "k8s.io/client-go/1.5/tools/auth",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "BD1LMXYvBXdSvGxvtd1f91eUk0k=",
+			"origin": "github.com/kubernetes/client-go/1.5/tools/clientcmd",
+			"path": "k8s.io/client-go/1.5/tools/clientcmd",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "7MXZw7BQkNlOuNo+lZ7P+YNR4/w=",
+			"origin": "github.com/kubernetes/client-go/1.5/tools/clientcmd/api",
+			"path": "k8s.io/client-go/1.5/tools/clientcmd/api",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "zvHTXHvPRBmtudMiLG/wW18riDs=",
+			"origin": "github.com/kubernetes/client-go/1.5/tools/clientcmd/api/latest",
+			"path": "k8s.io/client-go/1.5/tools/clientcmd/api/latest",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "zof0OTr7mTbivg6ZXKTZQAu6Ssg=",
+			"origin": "github.com/kubernetes/client-go/1.5/tools/clientcmd/api/v1",
+			"path": "k8s.io/client-go/1.5/tools/clientcmd/api/v1",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "c1PQ4WJRfpA9BYcFHW2+46hu5IE=",
+			"origin": "github.com/kubernetes/client-go/1.5/tools/metrics",
+			"path": "k8s.io/client-go/1.5/tools/metrics",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
+		},
+		{
+			"checksumSHA1": "S4TmHN1KVlxyW9kNYvbcCN/H0jg=",
+			"origin": "github.com/kubernetes/client-go/1.5/transport",
+			"path": "k8s.io/client-go/1.5/transport",
+			"revision": "843f7c4f28b1f647f664f883697107d5c02c5acc",
+			"revisionTime": "2016-10-23T20:27:10Z",
+			"version": "=release-1.5",
+			"versionExact": "release-1.5"
 		}
 	],
 	"rootPath": "github.com/wercker/stern"


### PR DESCRIPTION
This required an upgrade to the 1.5 client.

Fixes #9 