### PR TITLE
Use namespace from current context

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | `--container`   | `.*`             | Container name when multiple containers in pod (regular expression)                      |
 | `--timestamps`  |                  | Print timestamps                                                                         |
 | `--since`       |                  | Return logs newer than a relative duration like 52, 2m, or 3h. Displays all if omitted   |
-| `--context`     |                  | Kubernetes context to use                                                                |
+| `--context`     |                  | Kubernetes context to use. Default to `kubectl config current-context`                   |
 | `--exclude`     |                  | Log lines to exclude; specify multiple with additional `--exclude`; (regular expression) |
-| `--namespace`   |                  | Kubernetes namespace to use                                                              |
+| `--namespace`   |                  | Kubernetes namespace to use. Default to namespace configured in Kubernetes context       |
 | `--kube-config` | `~/.kube/config` | Path to kubeconfig file to use                                                           |
 
 See `stern --help` for details

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | `--since`       |                  | Return logs newer than a relative duration like 52, 2m, or 3h. Displays all if omitted   |
 | `--context`     |                  | Kubernetes context to use                                                                |
 | `--exclude`     |                  | Log lines to exclude; specify multiple with additional `--exclude`; (regular expression) |
-| `--namespace`   | `default`        | Kubernetes namespace to use                                                              |
+| `--namespace`   |                  | Kubernetes namespace to use                                                              |
 | `--kube-config` | `~/.kube/config` | Path to kubeconfig file to use                                                           |
 
 See `stern --help` for details

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -52,12 +52,12 @@ func Run() {
 		},
 		cli.StringFlag{
 			Name:  "context",
-			Usage: "Kubernetes context to use",
+			Usage: "Kubernetes context to use. Default to `kubectl config current-context`",
 			Value: "",
 		},
 		cli.StringFlag{
 			Name:  "namespace, n",
-			Usage: "Kubernetes namespace to use",
+			Usage: "Kubernetes namespace to use. Default to namespace configured in Kubernetes context",
 			Value: "",
 		},
 		cli.StringFlag{

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -58,7 +58,7 @@ func Run() {
 		cli.StringFlag{
 			Name:  "namespace, n",
 			Usage: "Kubernetes namespace to use",
-			Value: "default",
+			Value: "",
 		},
 		cli.StringFlag{
 			Name:   "kube-config",

--- a/kubernetes/clientset.go
+++ b/kubernetes/clientset.go
@@ -24,14 +24,19 @@ import (
 	_ "k8s.io/client-go/1.5/plugin/pkg/client/auth/oidc"
 )
 
-// NewClientSet returns a new Kubernetes client set for a context
-func NewClientSet(configPath string, contextName string) (*kubernetes.Clientset, error) {
-	c, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+// NewClientConfig returns a new Kubernetes client config set for a context
+func NewClientConfig(configPath string, contextName string) clientcmd.ClientConfig {
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 		&clientcmd.ClientConfigLoadingRules{ExplicitPath: configPath},
 		&clientcmd.ConfigOverrides{
 			CurrentContext: contextName,
 		},
-	).ClientConfig()
+	)
+}
+
+// NewClientSet returns a new Kubernetes client for a client config
+func NewClientSet(clientConfig clientcmd.ClientConfig) (*kubernetes.Clientset, error) {
+	c, err := clientConfig.ClientConfig()
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get client config")


### PR DESCRIPTION
This PR makes stern get the namespace from the current context. User can still override the namespace by using the `--namespace` switch.

fixes #3