### PR TITLE
Split Linux and MacOS build

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -15,7 +15,7 @@ build:
         code: govendor sync
 
     - script:
-        name: build binaries
+        name: go build linux amd64
         code: |
             export CGO_ENABLED=0
             GOOS=linux GOARCH=amd64 go build \
@@ -23,12 +23,18 @@ build:
                 -installsuffix cgo \
                 -o $WERCKER_OUTPUT_DIR/artifacts/latest/linux_amd64/stern
 
+            cp $WERCKER_OUTPUT_DIR/artifacts/latest/linux_amd64/stern $WERCKER_REPORT_ARTIFACTS_DIR
+
+    - script:
+        name: go build darwin amd64
+        code: |
+            export CGO_ENABLED=0
             GOOS=darwin GOARCH=amd64 go build \
                 -ldflags="-s -X github.com/wercker/stern.GitCommit=$WERCKER_GIT_COMMIT -X github.com/wercker/stern.PatchVersion=$(( ($(date +%s) - $(date --date=20150101 +%s) )/(60*60*24) )) -X github.com/wercker/stern.Compiled=$(date +%s)" \
                 -installsuffix cgo \
                 -o $WERCKER_OUTPUT_DIR/artifacts/latest/darwin_amd64/stern
 
-            cp -r $WERCKER_OUTPUT_DIR/artifacts/latest/* $WERCKER_REPORT_ARTIFACTS_DIR
+            cp $WERCKER_OUTPUT_DIR/artifacts/latest/darwin_amd64/stern $WERCKER_REPORT_ARTIFACTS_DIR
 
     - script:
         name: generate SHAs


### PR DESCRIPTION
This allows us to download only a single binary as a Wercker artifact.