### PR TITLE
Add --tail flag to show a certain number of lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | `--kube-config`    | `~/.kube/config` | Path to kubeconfig file to use                                                                              |
 | `--all-namespaces` |                  | If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace. |
 | `--selector`       |                  | Selector (label query) to filter on. If present, default to `.*` for the pod-query.                         |
+| `--tail`           | `-1`             | The number of lines from the end of the logs to show. Defaults to -1, showing all logs. |
 
 See `stern --help` for details
 

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -82,6 +82,11 @@ func Run() {
 			Usage: "Selector (label query) to filter on. If present, default to `.*` for the pod-query.",
 			Value: "",
 		},
+		cli.Int64Flag{
+			Name:  "tail",
+			Usage: "The number of lines from the end of the logs to show. Defaults to -1, showing all logs.",
+			Value: -1,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {
@@ -161,6 +166,11 @@ func parseConfig(c *cli.Context) (*stern.Config, error) {
 		}
 	}
 
+	var tailLines *int64
+	if tail := c.Int64("tail"); tail != -1 {
+		tailLines = &tail
+	}
+
 	return &stern.Config{
 		KubeConfig:     kubeConfig,
 		PodQuery:       pod,
@@ -172,5 +182,6 @@ func parseConfig(c *cli.Context) (*stern.Config, error) {
 		Namespace:      c.String("namespace"),
 		AllNamespaces:  c.Bool("all-namespaces"),
 		LabelSelector:  labelSelector,
+		TailLines:      tailLines,
 	}, nil
 }

--- a/stern/config.go
+++ b/stern/config.go
@@ -33,4 +33,5 @@ type Config struct {
 	Since          time.Duration
 	AllNamespaces  bool
 	LabelSelector  labels.Selector
+	TailLines      *int64
 }

--- a/stern/main.go
+++ b/stern/main.go
@@ -62,6 +62,7 @@ func Run(ctx context.Context, config *Config) error {
 				SinceSeconds: int64(config.Since.Seconds()),
 				Exclude:      config.Exclude,
 				Namespace:    config.AllNamespaces,
+				TailLines:    config.TailLines,
 			})
 			tails[id] = tail
 

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -44,6 +44,7 @@ type TailOptions struct {
 	SinceSeconds int64
 	Exclude      []*regexp.Regexp
 	Namespace    bool
+	TailLines    *int64
 }
 
 // NewTail returns a new tail for a Kubernetes container inside a pod
@@ -91,6 +92,7 @@ func (t *Tail) Start(ctx context.Context, i corev1.PodInterface) {
 			Timestamps:   t.Options.Timestamps,
 			Container:    t.ContainerName,
 			SinceSeconds: &t.Options.SinceSeconds,
+			TailLines:    t.Options.TailLines,
 		})
 
 		stream, err := req.Stream()


### PR DESCRIPTION
This commit adds `--tail` flag to show a certain number of lines. It is equivalent to `kubectl log`'s `--tail` flag.