### PR TITLE
Fix kubeconfig order

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 
 See `stern --help` for details
 
+Stern will use the `$KUBECONFIG` environment variable if set. If both the
+environment variable and `--kubeconfig` flag are passed the cli flag will be
+used.
+
 ## Examples:
 
 Tail the `gateway` container running inside of the `envvars` pod on staging

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -205,11 +205,11 @@ func parseConfig(args []string) (*stern.Config, error) {
 func getKubeConfig() (string, error) {
 	var kubeconfig string
 
-	if kubeconfig = os.Getenv("KUBECONFIG"); kubeconfig != "" {
+	if kubeconfig = opts.kubeConfig; kubeconfig != "" {
 		return kubeconfig, nil
 	}
 
-	if kubeconfig = opts.kubeConfig; kubeconfig != "" {
+	if kubeconfig = os.Getenv("KUBECONFIG"); kubeconfig != "" {
 		return kubeconfig, nil
 	}
 


### PR DESCRIPTION
The order of which kubeconfig to use changed accidentally in 41697a5d72fdea156df74f26b865e242be5faa2c. This PR updates it so that the cli flag will override the environment variable if both are set.

Fixes #45 