### PR TITLE
Remove terminated pods (crash/crashloopbackoff)

### DIFF
--- a/stern/watch.go
+++ b/stern/watch.go
@@ -93,6 +93,14 @@ func Watch(ctx context.Context, i corev1.PodInterface, podFilter *regexp.Regexp,
 								Container: c.Name,
 							}
 						}
+
+						if c.State.Terminated != nil {
+							removed <- &Target{
+								Namespace: pod.Namespace,
+								Pod:       pod.Name,
+								Container: c.Name,
+							}
+						}
 					}
 				case watch.Deleted:
 					for _, container := range pod.Spec.Containers {


### PR DESCRIPTION
When a container exits, stern loses the stream.  I wasn't sure how to have the stream reconnect however terminating the stream when state is terminated works quite well. 

Potentially fixes https://github.com/wercker/stern/issues/55