### PR TITLE
fix: Handle multiple kubeconfig files like kubectl

### DIFF
--- a/kubernetes/clientset.go
+++ b/kubernetes/clientset.go
@@ -15,6 +15,8 @@
 package kubernetes
 
 import (
+	"path/filepath"
+
 	"github.com/pkg/errors"
 	"k8s.io/client-go/1.5/kubernetes"
 	"k8s.io/client-go/1.5/tools/clientcmd"
@@ -26,8 +28,15 @@ import (
 
 // NewClientConfig returns a new Kubernetes client config set for a context
 func NewClientConfig(configPath string, contextName string) clientcmd.ClientConfig {
+	configPathList := filepath.SplitList(configPath)
+	configLoadingRules := &clientcmd.ClientConfigLoadingRules{}
+	if len(configPathList) <= 1 {
+		configLoadingRules.ExplicitPath = configPath
+	} else {
+		configLoadingRules.Precedence = configPathList
+	}
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
-		&clientcmd.ClientConfigLoadingRules{ExplicitPath: configPath},
+		configLoadingRules,
 		&clientcmd.ConfigOverrides{
 			CurrentContext: contextName,
 		},


### PR DESCRIPTION
if multiple files specified (strings split with :) load all files and
merge config

fixes #52