### PR TITLE
Support tailing init containers and passing container state

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | flag               | default          | purpose                                                                                                      |
 |--------------------|------------------|--------------------------------------------------------------------------------------------------------------|
 | `--container`      | `.*`             | Container name when multiple containers in pod (regular expression)                                          |
+| `--container-state`| `running`        | Tail containers with status in running, waiting or terminated. Default to running.
 | `--timestamps`     |                  | Print timestamps                                                                                             |
 | `--since`          |                  | Return logs newer than a relative duration like 52, 2m, or 3h. Displays all if omitted                       |
 | `--context`        |                  | Kubernetes context to use. Default to `kubectl config current-context`                                       |

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 | flag               | default          | purpose                                                                                                      |
 |--------------------|------------------|--------------------------------------------------------------------------------------------------------------|
 | `--container`      | `.*`             | Container name when multiple containers in pod (regular expression)                                          |
-| `--container-state`| `running`        | Tail containers with status in running, waiting or terminated. Default to running.
+| `--container-state`| `running`        | Tail containers with status in running, waiting or terminated. Default to running.                           |
 | `--timestamps`     |                  | Print timestamps                                                                                             |
 | `--since`          |                  | Return logs newer than a relative duration like 52, 2m, or 3h. Displays all if omitted                       |
 | `--context`        |                  | Kubernetes context to use. Default to `kubectl config current-context`                                       |

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -36,25 +36,27 @@ import (
 const version = "1.6.0"
 
 type Options struct {
-	container     string
-	timestamps    bool
-	since         time.Duration
-	context       string
-	namespace     string
-	kubeConfig    string
-	exclude       []string
-	allNamespaces bool
-	selector      string
-	tail          int64
-	color         string
-	version       bool
-	completion    string
+	container      string
+	containerState string
+	timestamps     bool
+	since          time.Duration
+	context        string
+	namespace      string
+	kubeConfig     string
+	exclude        []string
+	allNamespaces  bool
+	selector       string
+	tail           int64
+	color          string
+	version        bool
+	completion     string
 }
 
 var opts = &Options{
-	container: ".*",
-	tail:      -1,
-	color:     "auto",
+	container:      ".*",
+	containerState: "running",
+	tail:           -1,
+	color:          "auto",
 }
 
 func Run() {
@@ -63,6 +65,7 @@ func Run() {
 	cmd.Short = "Tail multiple pods and containers from Kubernetes"
 
 	cmd.Flags().StringVarP(&opts.container, "container", "c", opts.container, "Container name when multiple containers in pod")
+	cmd.Flags().StringVar(&opts.containerState, "container-state", opts.containerState, "If present, tail containers with status in running, waiting or terminated. Default to running.")
 	cmd.Flags().BoolVarP(&opts.timestamps, "timestamps", "t", opts.timestamps, "Print timestamps")
 	cmd.Flags().DurationVarP(&opts.since, "since", "s", opts.since, "Return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.")
 	cmd.Flags().StringVar(&opts.context, "context", opts.context, "Kubernetes context to use. Default to current context configured in kubeconfig.")
@@ -162,6 +165,11 @@ func parseConfig(args []string) (*stern.Config, error) {
 		exclude = append(exclude, rex)
 	}
 
+	containerState, err := stern.NewContainerState(opts.containerState)
+	if err != nil {
+		return nil, err
+	}
+
 	var labelSelector labels.Selector
 	selector := opts.selector
 	if selector == "" {
@@ -191,6 +199,7 @@ func parseConfig(args []string) (*stern.Config, error) {
 		KubeConfig:     kubeConfig,
 		PodQuery:       pod,
 		ContainerQuery: container,
+		ContainerState: containerState,
 		Exclude:        exclude,
 		Timestamps:     opts.timestamps,
 		Since:          opts.since,

--- a/stern/config.go
+++ b/stern/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	PodQuery       *regexp.Regexp
 	Timestamps     bool
 	ContainerQuery *regexp.Regexp
+	ContainerState ContainerState
 	Exclude        []*regexp.Regexp
 	Since          time.Duration
 	AllNamespaces  bool

--- a/stern/container_state.go
+++ b/stern/container_state.go
@@ -1,0 +1,47 @@
+//   Copyright 2016 Wercker Holding BV
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
+package stern
+
+import (
+	"errors"
+
+	"k8s.io/api/core/v1"
+)
+
+type ContainerState string
+
+const (
+	RUNNING    = "running"
+	WAITING    = "waiting"
+	TERMINATED = "terminated"
+)
+
+func NewContainerState(stateConfig string) (ContainerState, error) {
+	if stateConfig == RUNNING {
+		return RUNNING, nil
+	} else if stateConfig == WAITING {
+		return WAITING, nil
+	} else if stateConfig == TERMINATED {
+		return TERMINATED, nil
+	}
+
+	return "", errors.New("containerState should be one of 'running', 'waiting', or 'terminated'")
+}
+
+func (stateConfig ContainerState) Match(containerState v1.ContainerState) bool {
+	return (stateConfig == RUNNING && containerState.Running != nil) ||
+		(stateConfig == WAITING && containerState.Waiting != nil) ||
+		(stateConfig == TERMINATED && containerState.Terminated != nil)
+}

--- a/stern/main.go
+++ b/stern/main.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, config *Config) error {
 		}
 	}
 
-	added, removed, err := Watch(ctx, clientset.Core().Pods(namespace), config.PodQuery, config.ContainerQuery, config.LabelSelector)
+	added, removed, err := Watch(ctx, clientset.Core().Pods(namespace), config.PodQuery, config.ContainerQuery, config.ContainerState, config.LabelSelector)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up watch")
 	}


### PR DESCRIPTION
The existing watch doesn't listen for init container and it only listens to container in running state. Supporting init containers and container state is useful to users. In order not to bother users passing container state every time, the flag has the default value of "running". https://github.com/wercker/stern/issues/53
