### PR TITLE
add exclude-container option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,22 +46,23 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 
 ### cli flags
 
-| flag               | default          | purpose                                                                                                      |
-|--------------------|------------------|--------------------------------------------------------------------------------------------------------------|
-| `--container`      | `.*`             | Container name when multiple containers in pod (regular expression)                                          |
-| `--container-state`| `running`        | Tail containers with status in running, waiting or terminated. Default to running.                           |
-| `--timestamps`     |                  | Print timestamps                                                                                             |
-| `--since`          |                  | Return logs newer than a relative duration like 52, 2m, or 3h. Displays all if omitted                       |
-| `--context`        |                  | Kubernetes context to use. Default to `kubectl config current-context`                                       |
-| `--exclude`        |                  | Log lines to exclude; specify multiple with additional `--exclude`; (regular expression)                     |
-| `--namespace`      |                  | Kubernetes namespace to use. Default to namespace configured in Kubernetes context                           |
-| `--kubeconfig`     | `~/.kube/config` | Path to kubeconfig file to use                                                                               |
-| `--all-namespaces` |                  | If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.  |
-| `--selector`       |                  | Selector (label query) to filter on. If present, default to `.*` for the pod-query.                          |
-| `--tail`           | `-1`             | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.                      |
-| `--color`          | `auto`           | Force set color output. `auto`: colorize if tty attached, `always`: always colorize, `never`: never colorize |
-| `--output`         | `default`        | Specify predefined template. Currently support: [default, raw, json] See templates section                   |
-| `template`         |                  | Template to use for log lines, leave empty to use --output flag                                              |
+| flag                 | default          | purpose                                                                                                      |
+|----------------------|------------------|--------------------------------------------------------------------------------------------------------------|
+| `--container`        | `.*`             | Container name when multiple containers in pod (regular expression)                                          |
+| `--exclude-container`|                  | Container name to exclude when multiple containers in pod (regular expression)                               |
+| `--container-state`  | `running`        | Tail containers with status in running, waiting or terminated. Default to running.                           |
+| `--timestamps`       |                  | Print timestamps                                                                                             |
+| `--since`            |                  | Return logs newer than a relative duration like 52, 2m, or 3h. Displays all if omitted                       |
+| `--context`          |                  | Kubernetes context to use. Default to `kubectl config current-context`                                       |
+| `--exclude`          |                  | Log lines to exclude; specify multiple with additional `--exclude`; (regular expression)                     |
+| `--namespace`        |                  | Kubernetes namespace to use. Default to namespace configured in Kubernetes context                           |
+| `--kubeconfig`       | `~/.kube/config` | Path to kubeconfig file to use                                                                               |
+| `--all-namespaces`   |                  | If present, tail across all namespaces. A specific namespace is ignored even if specified with --namespace.  |
+| `--selector`         |                  | Selector (label query) to filter on. If present, default to `.*` for the pod-query.                          |
+| `--tail`             | `-1`             | The number of lines from the end of the logs to show. Defaults to -1, showing all logs.                      |
+| `--color`            | `auto`           | Force set color output. `auto`: colorize if tty attached, `always`: always colorize, `never`: never colorize |
+| `--output`           | `default`        | Specify predefined template. Currently support: [default, raw, json] See templates section                   |
+| `template`           |                  | Template to use for log lines, leave empty to use --output flag                                              |
 
 See `stern --help` for details
 
@@ -104,6 +105,11 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 Tail the `gateway` container running inside of the `envvars` pod on staging
 ```
 stern envvars --context staging --container gateway
+```
+
+Tail the `staging` namespace excluding logs from `istio-proxy` container
+```
+stern -n staging --exclude-container istio-proxy .
 ```
 
 Show auth activity from 15min ago with timestamps

--- a/stern/config.go
+++ b/stern/config.go
@@ -24,17 +24,18 @@ import (
 
 // Config contains the config for stern
 type Config struct {
-	KubeConfig     string
-	ContextName    string
-	Namespace      string
-	PodQuery       *regexp.Regexp
-	Timestamps     bool
-	ContainerQuery *regexp.Regexp
-	ContainerState ContainerState
-	Exclude        []*regexp.Regexp
-	Since          time.Duration
-	AllNamespaces  bool
-	LabelSelector  labels.Selector
-	TailLines      *int64
-	Template       *template.Template
+	KubeConfig            string
+	ContextName           string
+	Namespace             string
+	PodQuery              *regexp.Regexp
+	Timestamps            bool
+	ContainerQuery        *regexp.Regexp
+	ExcludeContainerQuery *regexp.Regexp
+	ContainerState        ContainerState
+	Exclude               []*regexp.Regexp
+	Since                 time.Duration
+	AllNamespaces         bool
+	LabelSelector         labels.Selector
+	TailLines             *int64
+	Template              *template.Template
 }

--- a/stern/main.go
+++ b/stern/main.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, config *Config) error {
 		}
 	}
 
-	added, removed, err := Watch(ctx, clientset.Core().Pods(namespace), config.PodQuery, config.ContainerQuery, config.ContainerState, config.LabelSelector)
+	added, removed, err := Watch(ctx, clientset.Core().Pods(namespace), config.PodQuery, config.ContainerQuery, config.ExcludeContainerQuery, config.ContainerState, config.LabelSelector)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up watch")
 	}


### PR DESCRIPTION
Tried it locally, it helps a lot :)

this fixes #78 

This excludes logs from a container matching the `exclude-container` filter.
I updated the docs.

If no option is passed we set the regexp pointer to nil and nothing is run.

To validate changes try it, since there are no tests, for me it was: `stern -n staging  . -E "istio"` just like in the doc update I did, and it worked !