### PR TITLE
Fix for running inside openshift

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -278,6 +278,9 @@ func getKubeConfig() (string, error) {
 	}
 
 	kubeconfig = filepath.Join(home, ".kube/config")
+	if _, err := os.Stat(kubeconfig); os.IsNotExist(err) {
+		return "", nil
+	}
 
 	return kubeconfig, nil
 }


### PR DESCRIPTION
In case ~/.kube/config file is not found, then keep empty kube config file path, thus allowing kube client to pickup InCluster config.

This allows to start inside openshift