### PR TITLE
Always hash to the same color

### DIFF
--- a/stern/tail_test.go
+++ b/stern/tail_test.go
@@ -1,0 +1,18 @@
+package stern
+
+import "testing"
+
+func TestDetermineColor(t *testing.T) {
+	podName := "stern"
+	podColor1, containerColor1 := determineColor(podName)
+	podColor2, containerColor2 := determineColor(podName)
+
+	if podColor1 != podColor2 {
+		t.Errorf("expected color for pod to be the same between invocations but was %v and %v",
+			podColor1, podColor2)
+	}
+	if containerColor1 != containerColor2 {
+		t.Errorf("expected color for container to be the same between invocations but was %v and %v",
+			containerColor1, containerColor2)
+	}
+}


### PR DESCRIPTION
This is something that bugged me:
* you run stern and watch the output of several pods fly by
* you realize you need to change a parameter flag
* you exit stern and restart it again
* the pods have different colors...

This change always hashes a pod's name to the same color instead of giving it a random one.
I hope I'm not the only one who would like to see this changed :grin: 

BTW: great project! Using it every day.