### PR TITLE
Describe usage of stern-provided colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ will receive the following struct:
 The following functions are available within the template (besides the [builtin
 functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 
-| func    | arguments             | description                                     |
-|---------|-----------------------|-------------------------------------------------|
-| `json`  | `object`              | Marshal the object and output it as a json text |
-| `color` | `color.Color, string` | Wrap the text in color                          |
+| func    | arguments             | description                                                     |
+|---------|-----------------------|-----------------------------------------------------------------|
+| `json`  | `object`              | Marshal the object and output it as a json text                 |
+| `color` | `color.Color, string` | Wrap the text in color (.containerColor and .podColor provided) |
+
+
 
 ## Examples:
 
@@ -145,6 +147,12 @@ Output using a custom template:
 
 ```
 stern --template '{{.Message}} ({{.Namespace}}/{{.PodName}}/{{.ContainerName}})' backend
+```
+
+Output using a custom template with stern-provided colors:
+
+```
+stern --template '{{.Message}} ({{.Namespace}}/{{color .podColor .PodName}}/{{color .containerColor .ContainerName}})' backend
 ```
 
 ## Completion


### PR DESCRIPTION
Following up from GitHub Issue: https://github.com/wercker/stern/issues/91

I love this library, but as a Golang novice I had some trouble getting started with using its templates. I believe I can help by adding a tad more exposure of stern-provided colors available for use in the templates.

- Add example of color usage in custom template
- Mention provided colors in the table of provided functions

Signed-off-by: Alan Cham <alanchamis@gmail.com>