### PR TITLE
Add an option to exclude pods when tailing logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The `pod` query is a regular expression so you could provide `"web-\w"` to tail
 
 | flag                 | default          | purpose                                                                                                      |
 |----------------------|------------------|--------------------------------------------------------------------------------------------------------------|
+| `--exclude-pod`      |                  | Pods to exclude when tailing logs                                                                            |
 | `--container`        | `.*`             | Container name when multiple containers in pod (regular expression)                                          |
 | `--exclude-container`|                  | Container name to exclude when multiple containers in pod (regular expression)                               |
 | `--container-state`  | `running`        | Tail containers with status in running, waiting or terminated. Default to running.                           |

--- a/stern/config.go
+++ b/stern/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	ContextName           string
 	Namespace             string
 	PodQuery              *regexp.Regexp
+	ExcludePodQuery       *regexp.Regexp
 	Timestamps            bool
 	ContainerQuery        *regexp.Regexp
 	ExcludeContainerQuery *regexp.Regexp

--- a/stern/main.go
+++ b/stern/main.go
@@ -43,7 +43,7 @@ func Run(ctx context.Context, config *Config) error {
 		}
 	}
 
-	added, removed, err := Watch(ctx, clientset.Core().Pods(namespace), config.PodQuery, config.ContainerQuery, config.ExcludeContainerQuery, config.ContainerState, config.LabelSelector)
+	added, removed, err := Watch(ctx, clientset.Core().Pods(namespace), config.PodQuery, config.ExcludePodQuery, config.ContainerQuery, config.ExcludeContainerQuery, config.ContainerState, config.LabelSelector)
 	if err != nil {
 		return errors.Wrap(err, "failed to set up watch")
 	}

--- a/stern/watch.go
+++ b/stern/watch.go
@@ -43,7 +43,7 @@ func (t *Target) GetID() string {
 // Watch starts listening to Kubernetes events and emits modified
 // containers/pods. The first result is targets added, the second is targets
 // removed
-func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, containerFilter *regexp.Regexp, containerExcludeFilter *regexp.Regexp, containerState ContainerState, labelSelector labels.Selector) (chan *Target, chan *Target, error) {
+func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, podExcludeFilter *regexp.Regexp, containerFilter *regexp.Regexp, containerExcludeFilter *regexp.Regexp, containerState ContainerState, labelSelector labels.Selector) (chan *Target, chan *Target, error) {
 	watcher, err := i.Watch(metav1.ListOptions{Watch: true, LabelSelector: labelSelector.String()})
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to set up watch")
@@ -63,7 +63,7 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 
 				pod := e.Object.(*corev1.Pod)
 
-				if !podFilter.MatchString(pod.Name) {
+				if !podFilter.MatchString(pod.Name) || (podExcludeFilter != nil && podExcludeFilter.MatchString(pod.Name)) {
 					continue
 				}
 


### PR DESCRIPTION
Fix #111 

I have been using a combination of `grep -v` and `awk -F '{print $1 }'` to exclude pods from the list of all pods (which have the same prefix, but the pods I don't want to tail have a particular string in them).

```sh
stern "`kubectl get pods | grep -i str1 | grep -iv str2 | awk '{ print $1 }' | paste -sd '|' -`"
```

I tried to use the current version of `stern` with negative look ahead, but I couldn't quite make it work (Anyway, this won't work whenever there is a character between `str1` and `str2`):

```sh
stern 'str1(?!str2)'
```

As there are include and exclude regular expressions for containers, I thought it would be useful to have an exclude regular expression for pods as well.

(Ideally, `exclude-pod` would be the `-v` shortcut command, to be in line with both `ag` and `grep`. But `-v` is already taken by `--version`, so I have used the obscure `-x` for this PR. If the maintainers would like, then I can remove the current `-v` shortcut to `--version` and use `-v` for `exclude-pod` instead)