### PR TITLE
Fix references to ContainerColor and PodColor in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ functions](https://golang.org/pkg/text/template/#hdr-Functions)):
 | func    | arguments             | description                                                     |
 |---------|-----------------------|-----------------------------------------------------------------|
 | `json`  | `object`              | Marshal the object and output it as a json text                 |
-| `color` | `color.Color, string` | Wrap the text in color (.containerColor and .podColor provided) |
+| `color` | `color.Color, string` | Wrap the text in color (.ContainerColor and .PodColor provided) |
 
 
 
@@ -158,7 +158,7 @@ stern --template '{{.Message}} ({{.Namespace}}/{{.PodName}}/{{.ContainerName}})'
 Output using a custom template with stern-provided colors:
 
 ```
-stern --template '{{.Message}} ({{.Namespace}}/{{color .podColor .PodName}}/{{color .containerColor .ContainerName}})' backend
+stern --template '{{.Message}} ({{.Namespace}}/{{color .PodColor .PodName}}/{{color .ContainerColor .ContainerName}})' backend
 ```
 
 ## Completion


### PR DESCRIPTION
This is only a issue in the documentation, as the code is already using the correct properties.