### PR TITLE
Use InClusterConfig when no config is supplied

### DIFF
--- a/kubernetes/clientset.go
+++ b/kubernetes/clientset.go
@@ -29,6 +29,10 @@ import (
 
 // NewClientConfig returns a new Kubernetes client config set for a context
 func NewClientConfig(configPath string, contextName string) clientcmd.ClientConfig {
+	if configPath == "" {
+		return nil
+	}
+
 	configPathList := filepath.SplitList(configPath)
 	configLoadingRules := &clientcmd.ClientConfigLoadingRules{}
 	if len(configPathList) <= 1 {
@@ -47,6 +51,12 @@ func NewClientConfig(configPath string, contextName string) clientcmd.ClientConf
 // NewClientSet returns a new Kubernetes client for a client config
 func NewClientSet(clientConfig clientcmd.ClientConfig) (*kubernetes.Clientset, error) {
 	c, err := clientConfig.ClientConfig()
+	if c == nil {
+		c, err = clientcmd.BuildConfigFromFlags("", "")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get inClusterConfig")
+		}
+	}
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get client config")


### PR DESCRIPTION
This will let stern run from within a cluster without any kubeconfig file. A serviceaccount token must be mounted in the pod in order for this to work.

This will work as long as everything else fails to get a config here: https://github.com/wercker/stern/blob/master/cmd/cli.go#L290