### PR TITLE
fix source in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Note that bash-completion must be sourced before sourcing the stern bash
 completion code in `.bashrc`.
 
 ```sh
-source <(brew --prefix)/etc/bash-completion
+source $(brew --prefix)/etc/bash_completion
 source <(stern --completion=bash)
 ```
 


### PR DESCRIPTION
fixed when we source `bash: /dev/fd/63/etc/bash-completion` also the file name is wrong. It is not dash but underscore