### PR TITLE
format file using go fmt

### DIFF
--- a/stern/tail.go
+++ b/stern/tail.go
@@ -140,7 +140,7 @@ func (t *Tail) Start(ctx context.Context, i v1.PodInterface) {
 						break
 					}
 				}
- 				if !matches {
+				if !matches {
 					continue OUTER
 				}
 			}


### PR DESCRIPTION
According to the gofmt report, `stern/tail.go` is not formatted.

So I help the source code clean through go fmt.