### PR TITLE
Add NodeName to template variables

### DIFF
--- a/stern/main.go
+++ b/stern/main.go
@@ -57,7 +57,7 @@ func Run(ctx context.Context, config *Config) error {
 				continue
 			}
 
-			tail := NewTail(p.Namespace, p.Pod, p.Container, config.Template, &TailOptions{
+			tail := NewTail(p.Namespace, p.Pod, p.Container, p.NodeName, config.Template, &TailOptions{
 				Timestamps:   config.Timestamps,
 				SinceSeconds: int64(config.Since.Seconds()),
 				Exclude:      config.Exclude,

--- a/stern/tail.go
+++ b/stern/tail.go
@@ -26,7 +26,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/rest"
 )
 
@@ -34,6 +34,7 @@ type Tail struct {
 	Namespace      string
 	PodName        string
 	ContainerName  string
+	NodeName       string
 	Options        *TailOptions
 	req            *rest.Request
 	closed         chan struct{}
@@ -52,11 +53,12 @@ type TailOptions struct {
 }
 
 // NewTail returns a new tail for a Kubernetes container inside a pod
-func NewTail(namespace, podName, containerName string, tmpl *template.Template, options *TailOptions) *Tail {
+func NewTail(namespace, podName, containerName, nodeName string, tmpl *template.Template, options *TailOptions) *Tail {
 	return &Tail{
 		Namespace:     namespace,
 		PodName:       podName,
 		ContainerName: containerName,
+		NodeName:      nodeName,
 		Options:       options,
 		closed:        make(chan struct{}),
 		tmpl:          tmpl,
@@ -140,7 +142,7 @@ func (t *Tail) Start(ctx context.Context, i v1.PodInterface) {
 						break
 					}
 				}
- 				if !matches {
+				if !matches {
 					continue OUTER
 				}
 			}
@@ -174,6 +176,7 @@ func (t *Tail) Print(msg string) {
 		Namespace:      t.Namespace,
 		PodName:        t.PodName,
 		ContainerName:  t.ContainerName,
+		NodeName:       t.NodeName,
 		PodColor:       t.podColor,
 		ContainerColor: t.containerColor,
 	}
@@ -197,6 +200,9 @@ type Log struct {
 
 	// ContainerName of the container
 	ContainerName string `json:"containerName"`
+
+	// Name of the node the pod is running on
+	NodeName string `json:"nodeName"`
 
 	PodColor       *color.Color `json:"-"`
 	ContainerColor *color.Color `json:"-"`

--- a/stern/watch.go
+++ b/stern/watch.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/typed/core/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
 // Target is a target to watch
@@ -33,6 +33,7 @@ type Target struct {
 	Namespace string
 	Pod       string
 	Container string
+	NodeName  string
 }
 
 // GetID returns the ID of the object
@@ -86,6 +87,7 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 								Namespace: pod.Namespace,
 								Pod:       pod.Name,
 								Container: c.Name,
+								NodeName:  pod.Spec.NodeName,
 							}
 						}
 					}
@@ -106,6 +108,7 @@ func Watch(ctx context.Context, i v1.PodInterface, podFilter *regexp.Regexp, con
 							Namespace: pod.Namespace,
 							Pod:       pod.Name,
 							Container: c.Name,
+							NodeName:  pod.Spec.NodeName,
 						}
 					}
 				}


### PR DESCRIPTION
This is very useful for debugging daemonsets that run on every node. In this case the name of the node is way more helpful then the generated pod name.